### PR TITLE
Fix for alternate helm release name

### DIFF
--- a/charts/flagsmith/templates/_helpers.tpl
+++ b/charts/flagsmith/templates/_helpers.tpl
@@ -130,6 +130,13 @@ Set redis port
 {{- end -}}
 
 {{/*
+Postgres hostname
+*/}}
+{{- define "flagsmith.postgres.hostname" -}}
+{{- printf "%s-%s" .Release.Name .Values.postgresql.nameOverride -}}.{{ .Release.Namespace }}.svc.cluster.local
+{{- end -}}
+
+{{/*
 Expand the name of the chart.
 */}}
 {{- define "influxdb.name" -}}

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -73,9 +73,9 @@ spec:
         - name: DJANGO_DB_PORT
           value: "5432"
         - name: DJANGO_DB_HOST
-          value: 'flagsmith-flagsmith-postgresql.{{ .Release.Namespace }}.svc.cluster.local'
+          value: {{ template "flagsmith.postgres.hostname" . }}
         - name: DATABASE_URL
-          value: postgres://{{.Values.postgresql.postgresqlUsername}}:{{ .Values.postgresql.postgresqlPassword}}@flagsmith-flagsmith-postgresql.{{ .Release.Namespace }}.svc.cluster.local:5432/{{ .Values.postgresql.postgresqlDatabase}}
+          value: postgres://{{.Values.postgresql.postgresqlUsername}}:{{ .Values.postgresql.postgresqlPassword}}@{{ template "flagsmith.postgres.hostname" . }}:5432/{{ .Values.postgresql.postgresqlDatabase}}
           
 {{- if .Values.api.env }}
 {{ toYaml .Values.api.env | indent 8 }}


### PR DESCRIPTION
I think this had previously assumed that the release name would always be `flagsmith`. This fixes to use the correct value.