### PR TITLE
Only lint and test changed charts

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -25,11 +25,20 @@ jobs:
         with:
           version: v3.3.0
 
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config ct.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
       - name: Run chart-testing (lint)
-        run: ct lint --config ct.yaml --all
+        run: ct lint --config ct.yaml
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.0.0
+        if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install --config ct.yaml --all
+        run: ct install --config ct.yaml


### PR DESCRIPTION
While there's only one chart, this is still useful as it means changes to things like the top-level README don't require the full KinD testing to run.