### PR TITLE
Fix chart icon to be a .png not .ico

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 2.2.0
 dependencies:
   - name: postgresql
     repository: https://charts.helm.sh/stable
     version: 8.6.4
     condition: postgresql.enabled
-icon: https://www.flagsmith.com/static/images/favicon.ico
+icon: https://docs.flagsmith.com/images/banner-logo-dark.png
 # maintainers:
 #   - name: Ben Rometsch, Matt Elwell
 #     email: support@flagsmith.com


### PR DESCRIPTION
Artifacthub was unhappy with a .ico. Docs at https://helm.sh/docs/topics/charts/ say it should be happy with a .png.

This might not be the right icon forever, but should do for the time being.