### PR TITLE
Chart NOTES.txt

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: 2.6.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/NOTES.txt
+++ b/charts/flagsmith/templates/NOTES.txt
@@ -1,0 +1,20 @@
+# Flagsmith pods are now starting in the cluster #
+
+See documentation at https://artifacthub.io/packages/helm/flagsmith/flagsmith/{{ .Chart.Version }}
+for more configuration options.
+
+{{ if not (and .Values.ingress.frontend.enabled .Values.ingress.api.enabled) }}
+
+{{- $noIngressFor := (list) -}}
+{{- if not .Values.ingress.api.enabled -}}{{- $noIngressFor = append $noIngressFor "api" -}}{{- end -}}
+{{- if not .Values.ingress.frontend.enabled -}}{{- $noIngressFor = append $noIngressFor "frontend" -}}{{- end -}}
+{{- $commaParts := (slice $noIngressFor 0 (sub (len $noIngressFor) 1)) -}}
+{{- $andPart := (last $noIngressFor) -}}
+{{- $stringParts := (compact (list (join ", " $commaParts) $andPart)) -}}
+## Ingress not enabled for {{ join " and " $stringParts }} ##
+
+See documentation at https://artifacthub.io/packages/helm/flagsmith/flagsmith/{{ .Chart.Version }}#ingress-configuration
+for information about how to gain web access to the application.
+
+{{- end }}
+


### PR DESCRIPTION
Prints a message to the console post-install, that looks a bit like:

```
NOTES:
# Flagsmith pods are now starting in the cluster #

See documentation at https://artifacthub.io/packages/helm/flagsmith/flagsmith/0.1.4
for more configuration options.

## Ingress not enabled for frontend and api ##

See documentation at https://artifacthub.io/packages/helm/flagsmith/flagsmith/0.1.4#ingress-configuration
for information about how to gain web access to the application.
```
Conditionally handles ingress for frontend and/or api being disabled, alerting the user to the need to gain web access.