### PR TITLE
Wait for DB to be ready before starting api containers

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: 2.6.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/README.md
+++ b/charts/flagsmith/README.md
@@ -7,8 +7,7 @@ helm repo add flagsmith https://flagsmith.github.io/flagsmith-charts/
 helm install flagsmith flagsmith/flagsmith
 ```
 
-This will install using default options. (Pods may error and restart
-while waiting for other pods to become ready.).
+This will install using default options.
 
 ### Ingress configuration
 
@@ -166,15 +165,19 @@ their default values.
 | `api.tolerations`                             |                                                          | `[]`                           |
 | `api.affinity`                                |                                                          | `{}`                           |
 | `api.livenessProbe.failureThreshold`          |                                                          | 5                              |
-| `api.livenessProbe.initialDelaySeconds`       |                                                          | 80                             |
+| `api.livenessProbe.initialDelaySeconds`       |                                                          | 10                             |
 | `api.livenessProbe.periodSeconds`             |                                                          | 10                             |
 | `api.livenessProbe.successThreshold`          |                                                          | 1                              |
 | `api.livenessProbe.timeoutSeconds`            |                                                          | 2                              |
 | `api.readinessProbe.failureThreshold`         |                                                          | 10                             |
-| `api.readinessProbe.initialDelaySeconds`      |                                                          | 50                             |
+| `api.readinessProbe.initialDelaySeconds`      |                                                          | 10                             |
 | `api.readinessProbe.periodSeconds`            |                                                          | 10                             |
 | `api.readinessProbe.successThreshold`         |                                                          | 1                              |
 | `api.readinessProbe.timeoutSeconds`           |                                                          | 2                              |
+| `api.dbWaiter.image.repository`               |                                                          | `willwill/wait-for-it`         |
+| `api.dbWaiter.image.tag`                      |                                                          | `latest`                       |
+| `api.dbWaiter.image.imagePullPolicy`          |                                                          | `IfNotPresent`                 |
+| `api.dbWaiter.timeoutSeconds`                 | Time before init container will retry                    | 30                             |
 | `frontend.enabled`                            | Whether the flagsmith frontend is enabled                | `true`                         |
 | `frontend.image.repository`                   | docker image repository for flagsmith frontend           | `flagsmith/flagsmith-frontend` |
 | `frontend.image.tag`                          | docker image tag for flagsmith frontend                  | appVersion                     |

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -47,6 +47,15 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.api.image.imagePullSecrets | indent 4 }}
       {{- end }}
+      initContainers:
+      - name: wait-for-db
+        image: {{ .Values.api.dbWaiter.image.repository }}:{{ .Values.api.dbWaiter.image.tag }}
+        imagePullPolicy: {{ .Values.api.dbWaiter.image.imagePullPolicy }}
+        command:
+          - /wait-for-it.sh
+          - --host={{ template "flagsmith.postgres.hostname" . }}
+          - --port=5432
+          - --timeout={{ .Values.api.dbWaiter.timeoutSeconds }}
       containers:
       - name: {{ .Chart.Name }}-api
         image: {{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default (printf "v%s" .Chart.AppVersion) }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -24,16 +24,22 @@ api:
     affinity: {}
     livenessProbe:
         failureThreshold: 5
-        initialDelaySeconds: 80
+        initialDelaySeconds: 10
         periodSeconds: 10
         successThreshold: 1
         timeoutSeconds: 2
     readinessProbe:
         failureThreshold: 10
-        initialDelaySeconds: 50
+        initialDelaySeconds: 10
         periodSeconds: 10
         successThreshold: 1
         timeoutSeconds: 2
+    dbWaiter:
+        image:
+            repository: willwill/wait-for-it
+            tag: latest
+            imagePullPolicy: IfNotPresent
+        timeoutSeconds: 30
 
 frontend:
     enabled: true


### PR DESCRIPTION
Makes use of `wait-for-it.sh` to check the DB is accessible before starting the API pods. This means they don't begin crashing, but rather just quietly wait.