### PR TITLE
Specify image tags, via appVersion

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.1.3
-appVersion: 2.2.0
+version: 0.1.4
+appVersion: 2.6.0
 dependencies:
   - name: postgresql
     repository: https://charts.helm.sh/stable

--- a/charts/flagsmith/README.md
+++ b/charts/flagsmith/README.md
@@ -138,7 +138,7 @@ their default values.
 | Parameter                                     | Description                                              | Default                        |
 | ---------                                     | ------------                                             | -------                        |
 | `api.image.repository`                        | docker image repository for flagsmith api                | `flagsmith/flagsmith-api`      |
-| `api.image.tag`                               | docker image tag for flagsmith api                       | `latest`                       |
+| `api.image.tag`                               | docker image tag for flagsmith api                       | appVersion                     |
 | `api.image.imagePullPolicy`                   |                                                          | `IfNotPresent`                 |
 | `api.image.imagePullSecrets`                  |                                                          | `[]`                           |
 | `api.replicacount`                            | number of replicas for the flagsmith api                 | 1                              |
@@ -149,7 +149,7 @@ their default values.
 | `api.tolerations`                             |                                                          | `[]`                           |
 | `api.affinity`                                |                                                          | `{}`                           |
 | `api.livenessProbe.failureThreshold`          |                                                          | 5                              |
-| `api.livenessProbe.initialDelaySeconds`       |                                                          | 50                             |
+| `api.livenessProbe.initialDelaySeconds`       |                                                          | 80                             |
 | `api.livenessProbe.periodSeconds`             |                                                          | 10                             |
 | `api.livenessProbe.successThreshold`          |                                                          | 1                              |
 | `api.livenessProbe.timeoutSeconds`            |                                                          | 2                              |
@@ -160,7 +160,7 @@ their default values.
 | `api.readinessProbe.timeoutSeconds`           |                                                          | 2                              |
 | `frontend.enabled`                            | Whether the flagsmith frontend is enabled                | `true`                         |
 | `frontend.image.repository`                   | docker image repository for flagsmith frontend           | `flagsmith/flagsmith-frontend` |
-| `frontend.image.tag`                          | docker image tag for flagsmith frontend                  | `test`                         |
+| `frontend.image.tag`                          | docker image tag for flagsmith frontend                  | appVersion                     |
 | `frontend.image.imagePullPolicy`              |                                                          | `IfNotPresent`                 |
 | `frontend.image.imagePullSecrets`             |                                                          | `[]`                           |
 | `frontend.replicacount`                       | number of replicas for the flagsmith frontend            | 1                              |

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -49,7 +49,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}-api
-        image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
+        image: {{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default (printf "v%s" .Chart.AppVersion) }}
         imagePullPolicy: {{ .Values.api.image.imagePullPolicy }}
         # command: ["sleep", "3600"]
         ports:

--- a/charts/flagsmith/templates/deployment-frontend.yaml
+++ b/charts/flagsmith/templates/deployment-frontend.yaml
@@ -49,7 +49,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}-frontend
-        image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
+        image: {{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag | default (printf "v%s" .Chart.AppVersion) }}
         imagePullPolicy: {{ .Values.frontend.image.imagePullPolicy }}
         ports:
         - containerPort: {{ .Values.service.frontend.port }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -3,7 +3,7 @@
 api:
     image:
         repository: flagsmith/flagsmith-api
-        tag: latest
+        tag: null  # defaults to .Chart.AppVersion
         imagePullPolicy: IfNotPresent
         imagePullSecrets: []
     replicacount: 1
@@ -24,7 +24,7 @@ api:
     affinity: {}
     livenessProbe:
         failureThreshold: 5
-        initialDelaySeconds: 50
+        initialDelaySeconds: 80
         periodSeconds: 10
         successThreshold: 1
         timeoutSeconds: 2
@@ -39,7 +39,7 @@ frontend:
     enabled: true
     image:
         repository: flagsmith/flagsmith-frontend
-        tag: test
+        tag: null  # defaults to .Chart.AppVersion
         imagePullPolicy: IfNotPresent
         imagePullSecrets: []
     replicacount: 1


### PR DESCRIPTION
Use known good tags, defaulting to version set in `Chart.yaml`'s `appVersion`.