### PR TITLE
Standard kubernetes labels

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.1.8
+version: 0.2.0
 appVersion: 2.6.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/_helpers.tpl
+++ b/charts/flagsmith/templates/_helpers.tpl
@@ -25,6 +25,33 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "flagsmith.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "flagsmith.labels" -}}
+helm.sh/chart: {{ include "flagsmith.chart" . }}
+{{ include "flagsmith.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "flagsmith.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "flagsmith.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -3,16 +3,13 @@ kind: Deployment
 metadata:
   name: {{ template "flagsmith.fullname" . }}-api
   labels:
-    app: {{ template "flagsmith.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "flagsmith.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
 spec:
   selector:
     matchLabels:
-      app: {{ template "flagsmith.fullname" . }}
-      release: "{{ .Release.Name }}"
-      role: api
+      {{- include "flagsmith.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: api
   replicas: {{ .Values.api.replicacount }}
   template:
     metadata:
@@ -21,9 +18,8 @@ spec:
 {{ toYaml .Values.api.podAnnotations | indent 8 }}
       {{- end }}
       labels:
-        app: {{ template "flagsmith.fullname" . }}
-        release: "{{ .Release.Name }}"
-        role: api
+        {{- include "flagsmith.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: api
         {{- if .Values.api.podLabels }}
 {{ toYaml .Values.api.podLabels | indent 8 }}
         {{- end }}

--- a/charts/flagsmith/templates/deployment-frontend.yaml
+++ b/charts/flagsmith/templates/deployment-frontend.yaml
@@ -3,16 +3,13 @@ kind: Deployment
 metadata:
   name: {{ template "flagsmith.fullname" . }}
   labels:
-    app: {{ template "flagsmith.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "flagsmith.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
 spec:
   selector:
     matchLabels:
-      app: {{ template "flagsmith.fullname" . }}
-      release: "{{ .Release.Name }}"
-      role: frontend
+      {{- include "flagsmith.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: frontend
   replicas: {{ .Values.frontend.replicacount }}
   template:
     metadata:
@@ -21,9 +18,8 @@ spec:
 {{ toYaml .Values.frontend.podAnnotations | indent 8 }}
       {{- end }}
       labels:
-        app: {{ template "flagsmith.fullname" . }}
-        release: "{{ .Release.Name }}"
-        role: frontend
+        {{- include "flagsmith.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: frontend
         {{- if .Values.frontend.podLabels }}
 {{ toYaml .Values.frontend.podLabels | indent 8 }}
         {{- end }}

--- a/charts/flagsmith/templates/ingress-api.yaml
+++ b/charts/flagsmith/templates/ingress-api.yaml
@@ -14,10 +14,8 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}-api
   labels:
-    app: {{ template "flagsmith.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "flagsmith.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
   {{- with .Values.ingress.api.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/flagsmith/templates/ingress-frontend.yaml
+++ b/charts/flagsmith/templates/ingress-frontend.yaml
@@ -14,10 +14,8 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}-frontend
   labels:
-    app: {{ template "flagsmith.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "flagsmith.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
   {{- with .Values.ingress.frontend.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/flagsmith/templates/routes-api.yaml
+++ b/charts/flagsmith/templates/routes-api.yaml
@@ -4,10 +4,8 @@ kind: Route
 metadata:
   name: flagsmith-api
   labels:
-    app: {{ template "flagsmith.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "flagsmith.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
 spec:
   host: flagsmith-api-{{ .Release.Namespace }}.{{ .Values.openshiftdomain }}
   port:

--- a/charts/flagsmith/templates/routes-frontend.yaml
+++ b/charts/flagsmith/templates/routes-frontend.yaml
@@ -4,10 +4,8 @@ kind: Route
 metadata:
   name: flagsmith-frontend
   labels:
-    app: {{ template "flagsmith.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "flagsmith.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
 spec:
   host: flagsmith-{{ .Release.Namespace }}.{{ .Values.openshiftdomain }}
   port:

--- a/charts/flagsmith/templates/secrets-api.yaml
+++ b/charts/flagsmith/templates/secrets-api.yaml
@@ -3,10 +3,8 @@ kind: Secret
 metadata:
   name: {{ template "flagsmith.fullname" . }}
   labels:
-    app: {{ template "flagsmith.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "flagsmith.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
 type: Opaque
 data:
   {{ if or (not .Values.postgresql.enabled) (.Values.postgresql.postgresqlUsername) }}

--- a/charts/flagsmith/templates/service-api.yaml
+++ b/charts/flagsmith/templates/service-api.yaml
@@ -3,10 +3,8 @@ kind: Service
 metadata:
   name: {{ include "flagsmith.fullname" . }}-api
   labels:
-    app: {{ template "flagsmith.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "flagsmith.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
 spec:
   type: {{ .Values.service.api.type }}
   ports:

--- a/charts/flagsmith/templates/service-frontend.yaml
+++ b/charts/flagsmith/templates/service-frontend.yaml
@@ -3,10 +3,8 @@ kind: Service
 metadata:
   name: {{ include "flagsmith.fullname" . }}-frontend
   labels:
-    app: {{ template "flagsmith.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "flagsmith.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
 spec:
   type: {{ .Values.service.frontend.type }}
   ports:


### PR DESCRIPTION
See https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/

Note: this is a breaking change, as updating the selector labels on the deployment will upset the running pods. Given we're at `0.1.x`, I think this is OK, but have bumped to `0.2.0`.