### PR TITLE
InfluxDB options and environment variables

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: 2.6.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/README.md
+++ b/charts/flagsmith/README.md
@@ -151,92 +151,101 @@ Currently this is used to measure:
 The following table lists the configurable parameters of the chart and
 their default values.
 
-| Parameter                                     | Description                                              | Default                        |
-| ---------                                     | ------------                                             | -------                        |
-| `api.image.repository`                        | docker image repository for flagsmith api                | `flagsmith/flagsmith-api`      |
-| `api.image.tag`                               | docker image tag for flagsmith api                       | appVersion                     |
-| `api.image.imagePullPolicy`                   |                                                          | `IfNotPresent`                 |
-| `api.image.imagePullSecrets`                  |                                                          | `[]`                           |
-| `api.replicacount`                            | number of replicas for the flagsmith api                 | 1                              |
-| `api.resources`                               | resources per pod for the flagsmith api                  | `{}`                           |
-| `api.podLabels`                               | additional labels to apply to pods for the flagsmith api | `{}`                           |
-| `api.env`                                     | environment variables to set for the flagsmith api       |                                |
-| `api.nodeSelector`                            |                                                          | `{}`                           |
-| `api.tolerations`                             |                                                          | `[]`                           |
-| `api.affinity`                                |                                                          | `{}`                           |
-| `api.livenessProbe.failureThreshold`          |                                                          | 5                              |
-| `api.livenessProbe.initialDelaySeconds`       |                                                          | 10                             |
-| `api.livenessProbe.periodSeconds`             |                                                          | 10                             |
-| `api.livenessProbe.successThreshold`          |                                                          | 1                              |
-| `api.livenessProbe.timeoutSeconds`            |                                                          | 2                              |
-| `api.readinessProbe.failureThreshold`         |                                                          | 10                             |
-| `api.readinessProbe.initialDelaySeconds`      |                                                          | 10                             |
-| `api.readinessProbe.periodSeconds`            |                                                          | 10                             |
-| `api.readinessProbe.successThreshold`         |                                                          | 1                              |
-| `api.readinessProbe.timeoutSeconds`           |                                                          | 2                              |
-| `api.dbWaiter.image.repository`               |                                                          | `willwill/wait-for-it`         |
-| `api.dbWaiter.image.tag`                      |                                                          | `latest`                       |
-| `api.dbWaiter.image.imagePullPolicy`          |                                                          | `IfNotPresent`                 |
-| `api.dbWaiter.timeoutSeconds`                 | Time before init container will retry                    | 30                             |
-| `frontend.enabled`                            | Whether the flagsmith frontend is enabled                | `true`                         |
-| `frontend.image.repository`                   | docker image repository for flagsmith frontend           | `flagsmith/flagsmith-frontend` |
-| `frontend.image.tag`                          | docker image tag for flagsmith frontend                  | appVersion                     |
-| `frontend.image.imagePullPolicy`              |                                                          | `IfNotPresent`                 |
-| `frontend.image.imagePullSecrets`             |                                                          | `[]`                           |
-| `frontend.replicacount`                       | number of replicas for the flagsmith frontend            | 1                              |
-| `frontend.resources`                          | resources per pod for the flagsmith frontend             | `{}`                           |
-| `frontend.env`                                | environment variables to set for the flagsmith frontend  |                                |
-| `frontend.nodeSelector`                       |                                                          | `{}`                           |
-| `frontend.tolerations`                        |                                                          | `[]`                           |
-| `frontend.affinity`                           |                                                          | `{}`                           |
-| `frontend.livenessProbe.failureThreshold`     |                                                          | 20                             |
-| `frontend.livenessProbe.initialDelaySeconds`  |                                                          | 20                             |
-| `frontend.livenessProbe.periodSeconds`        |                                                          | 10                             |
-| `frontend.livenessProbe.successThreshold`     |                                                          | 1                              |
-| `frontend.livenessProbe.timeoutSeconds`       |                                                          | 10                             |
-| `frontend.readinessProbe.failureThreshold`    |                                                          | 20                             |
-| `frontend.readinessProbe.initialDelaySeconds` |                                                          | 20                             |
-| `frontend.readinessProbe.periodSeconds`       |                                                          | 10                             |
-| `frontend.readinessProbe.successThreshold`    |                                                          | 1                              |
-| `frontend.readinessProbe.timeoutSeconds`      |                                                          | 10                             |
-| `postgresql.enabled`                          | if `true`, creates in-cluster PostgreSQL database        | `true`                         |
-| `postgresql.serviceAccount.enabled`           | creates a serviceaccount for the postgres pod            | `true`                         |
-| `nameOverride`                                |                                                          | `flagsmith-postgres`           |
-| `postgresqlDatabase`                          |                                                          | `flagsmith`                    |
-| `postgresqlUsername`                          |                                                          | `postgres`                     |
-| `postgresqlPassword`                          |                                                          | `flagsmith`                    |
-| `influxdb.nameOverride`                       |                                                          | `influxdb`                     |
-| `influxdb.image.repository`                   | docker image repository for influxdb                     | `quay.io/influxdb/influxdb`    |
-| `influxdb.image.tag`                          | docker image tag for influxdb                            | `v2.0.2`                       |
-| `influxdb.image.imagePullPolicy`              |                                                          | `IfNotPresent`                 |
-| `influxdb.image.imagePullSecrets`             |                                                          | `[]`                           |
-| `influxdb.adminUser.organization`             |                                                          | `influxdata`                   |
-| `influxdb.adminUser.bucket`                   |                                                          | `default`                      |
-| `influxdb.adminUser.user`                     |                                                          | `admin`                        |
-| `influxdb.adminUser.password`                 |                                                          | randomly generated             |
-| `influxdb.adminUser.token`                    |                                                          | randomly generated             |
-| `influxdb.persistence.enabled`                |                                                          | `false`                        |
-| `influxdb.resources`                          | resources per pod for the influxdb                       | `{}`                           |
-| `influxdb.nodeSelector`                       |                                                          | `{}`                           |
-| `influxdb.tolerations`                        |                                                          | `[]`                           |
-| `influxdb.affinity`                           |                                                          | `{}`                           |
-| `hooks.enabled`                               | Enables hooks (to migrate the db)                        | `false`                        |
-| `hooks.removeOnSuccess`                       |                                                          | `true`                         |
-| `service.influxdb.externalPort`               |                                                          | `8080`                         |
-| `service.api.type`                            |                                                          | `ClusterIP`                    |
-| `service.api.port`                            |                                                          | `8000`                         |
-| `service.frontend.type`                       |                                                          | `ClusterIP`                    |
-| `service.frontend.port`                       |                                                          | `8080`                         |
-| `ingress.frontend.enabled`                    |                                                          | `false`                        |
-| `ingress.frontend.annotations`                |                                                          | `{}`                           |
-| `ingress.frontend.hosts[].host`               |                                                          | `chart-example.local`          |
-| `ingress.frontend.hosts[].paths`              |                                                          | `[]`                           |
-| `ingress.frontend.tls`                        |                                                          | `[]`                           |
-| `ingress.api.enabled`                         |                                                          | `false`                        |
-| `ingress.api.annotations`                     |                                                          | `{}`                           |
-| `ingress.api.hosts[].host`                    |                                                          | `chart-example.local`          |
-| `ingress.api.hosts[].paths`                   |                                                          | `[]`                           |
-| `ingress.api.tls`                             |                                                          | `[]`                           |
+| Parameter                                          | Description                                              | Default                        |
+| ---------                                          | ------------                                             | -------                        |
+| `api.image.repository`                             | docker image repository for flagsmith api                | `flagsmith/flagsmith-api`      |
+| `api.image.tag`                                    | docker image tag for flagsmith api                       | appVersion                     |
+| `api.image.imagePullPolicy`                        |                                                          | `IfNotPresent`                 |
+| `api.image.imagePullSecrets`                       |                                                          | `[]`                           |
+| `api.replicacount`                                 | number of replicas for the flagsmith api                 | 1                              |
+| `api.resources`                                    | resources per pod for the flagsmith api                  | `{}`                           |
+| `api.podLabels`                                    | additional labels to apply to pods for the flagsmith api | `{}`                           |
+| `api.env`                                          | environment variables to set for the flagsmith api       |                                |
+| `api.nodeSelector`                                 |                                                          | `{}`                           |
+| `api.tolerations`                                  |                                                          | `[]`                           |
+| `api.affinity`                                     |                                                          | `{}`                           |
+| `api.livenessProbe.failureThreshold`               |                                                          | 5                              |
+| `api.livenessProbe.initialDelaySeconds`            |                                                          | 10                             |
+| `api.livenessProbe.periodSeconds`                  |                                                          | 10                             |
+| `api.livenessProbe.successThreshold`               |                                                          | 1                              |
+| `api.livenessProbe.timeoutSeconds`                 |                                                          | 2                              |
+| `api.readinessProbe.failureThreshold`              |                                                          | 10                             |
+| `api.readinessProbe.initialDelaySeconds`           |                                                          | 10                             |
+| `api.readinessProbe.periodSeconds`                 |                                                          | 10                             |
+| `api.readinessProbe.successThreshold`              |                                                          | 1                              |
+| `api.readinessProbe.timeoutSeconds`                |                                                          | 2                              |
+| `api.dbWaiter.image.repository`                    |                                                          | `willwill/wait-for-it`         |
+| `api.dbWaiter.image.tag`                           |                                                          | `latest`                       |
+| `api.dbWaiter.image.imagePullPolicy`               |                                                          | `IfNotPresent`                 |
+| `api.dbWaiter.timeoutSeconds`                      | Time before init container will retry                    | 30                             |
+| `frontend.enabled`                                 | Whether the flagsmith frontend is enabled                | `true`                         |
+| `frontend.image.repository`                        | docker image repository for flagsmith frontend           | `flagsmith/flagsmith-frontend` |
+| `frontend.image.tag`                               | docker image tag for flagsmith frontend                  | appVersion                     |
+| `frontend.image.imagePullPolicy`                   |                                                          | `IfNotPresent`                 |
+| `frontend.image.imagePullSecrets`                  |                                                          | `[]`                           |
+| `frontend.replicacount`                            | number of replicas for the flagsmith frontend            | 1                              |
+| `frontend.resources`                               | resources per pod for the flagsmith frontend             | `{}`                           |
+| `frontend.env`                                     | environment variables to set for the flagsmith frontend  |                                |
+| `frontend.nodeSelector`                            |                                                          | `{}`                           |
+| `frontend.tolerations`                             |                                                          | `[]`                           |
+| `frontend.affinity`                                |                                                          | `{}`                           |
+| `frontend.livenessProbe.failureThreshold`          |                                                          | 20                             |
+| `frontend.livenessProbe.initialDelaySeconds`       |                                                          | 20                             |
+| `frontend.livenessProbe.periodSeconds`             |                                                          | 10                             |
+| `frontend.livenessProbe.successThreshold`          |                                                          | 1                              |
+| `frontend.livenessProbe.timeoutSeconds`            |                                                          | 10                             |
+| `frontend.readinessProbe.failureThreshold`         |                                                          | 20                             |
+| `frontend.readinessProbe.initialDelaySeconds`      |                                                          | 20                             |
+| `frontend.readinessProbe.periodSeconds`            |                                                          | 10                             |
+| `frontend.readinessProbe.successThreshold`         |                                                          | 1                              |
+| `frontend.readinessProbe.timeoutSeconds`           |                                                          | 10                             |
+| `postgresql.enabled`                               | if `true`, creates in-cluster PostgreSQL database        | `true`                         |
+| `postgresql.serviceAccount.enabled`                | creates a serviceaccount for the postgres pod            | `true`                         |
+| `nameOverride`                                     |                                                          | `flagsmith-postgres`           |
+| `postgresqlDatabase`                               |                                                          | `flagsmith`                    |
+| `postgresqlUsername`                               |                                                          | `postgres`                     |
+| `postgresqlPassword`                               |                                                          | `flagsmith`                    |
+| `influxdb.enabled`                                 |                                                          | `true`                         |
+| `influxdb.nameOverride`                            |                                                          | `influxdb`                     |
+| `influxdb.image.repository`                        | docker image repository for influxdb                     | `quay.io/influxdb/influxdb`    |
+| `influxdb.image.tag`                               | docker image tag for influxdb                            | `v2.0.2`                       |
+| `influxdb.image.imagePullPolicy`                   |                                                          | `IfNotPresent`                 |
+| `influxdb.image.imagePullSecrets`                  |                                                          | `[]`                           |
+| `influxdb.adminUser.organization`                  |                                                          | `influxdata`                   |
+| `influxdb.adminUser.bucket`                        |                                                          | `default`                      |
+| `influxdb.adminUser.user`                          |                                                          | `admin`                        |
+| `influxdb.adminUser.password`                      |                                                          | randomly generated             |
+| `influxdb.adminUser.token`                         |                                                          | randomly generated             |
+| `influxdb.persistence.enabled`                     |                                                          | `false`                        |
+| `influxdb.resources`                               | resources per pod for the influxdb                       | `{}`                           |
+| `influxdb.nodeSelector`                            |                                                          | `{}`                           |
+| `influxdb.tolerations`                             |                                                          | `[]`                           |
+| `influxdb.affinity`                                |                                                          | `{}`                           |
+| `influxdbExternal.enabled`                         | Use an InfluxDB not managed by this chart                | `false`                        |
+| `influxdbExternal.url`                             |                                                          |                                |
+| `influxdbExternal.bucket`                          |                                                          |                                |
+| `influxdbExternal.organization`                    |                                                          |                                |
+| `influxdbExternal.token`                           |                                                          |                                |
+| `influxdbExternal.tokenFromExistingSecret.enabled` | Use reference to a k8s secret not managed by this chart  | `false`                        |
+| `influxdbExternal.tokenFromExistingSecret.name`    | Referenced secret name                                   |                                |
+| `influxdbExternal.tokenFromExistingSecret.key`     | Key within the referenced secret to use                  |                                |
+| `hooks.enabled`                                    | Enables hooks (to migrate the db)                        | `false`                        |
+| `hooks.removeOnSuccess`                            |                                                          | `true`                         |
+| `service.influxdb.externalPort`                    |                                                          | `8080`                         |
+| `service.api.type`                                 |                                                          | `ClusterIP`                    |
+| `service.api.port`                                 |                                                          | `8000`                         |
+| `service.frontend.type`                            |                                                          | `ClusterIP`                    |
+| `service.frontend.port`                            |                                                          | `8080`                         |
+| `ingress.frontend.enabled`                         |                                                          | `false`                        |
+| `ingress.frontend.annotations`                     |                                                          | `{}`                           |
+| `ingress.frontend.hosts[].host`                    |                                                          | `chart-example.local`          |
+| `ingress.frontend.hosts[].paths`                   |                                                          | `[]`                           |
+| `ingress.frontend.tls`                             |                                                          | `[]`                           |
+| `ingress.api.enabled`                              |                                                          | `false`                        |
+| `ingress.api.annotations`                          |                                                          | `{}`                           |
+| `ingress.api.hosts[].host`                         |                                                          | `chart-example.local`          |
+| `ingress.api.hosts[].paths`                        |                                                          | `[]`                           |
+| `ingress.api.tls`                                  |                                                          | `[]`                           |
 
 ---
 

--- a/charts/flagsmith/templates/_helpers.tpl
+++ b/charts/flagsmith/templates/_helpers.tpl
@@ -164,6 +164,13 @@ Postgres hostname
 {{- end -}}
 
 {{/*
+Influxdb hostname
+*/}}
+{{- define "flagsmith.influx.hostname" -}}
+{{- printf "%s-%s" .Release.Name .Values.influx.nameOverride -}}.{{ .Release.Namespace }}.svc.cluster.local
+{{- end -}}
+
+{{/*
 Expand the name of the chart.
 */}}
 {{- define "influxdb.name" -}}

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -13,10 +13,16 @@ spec:
   replicas: {{ .Values.api.replicacount }}
   template:
     metadata:
-      {{- if .Values.api.podAnnotations }}
       annotations:
-{{ toYaml .Values.api.podAnnotations | indent 8 }}
-      {{- end }}
+        {{- if .Values.influxdb.enabled }}
+        checksum/secrets-influxdb: {{ include (print $.Template.BasePath "/secrets-influxdb.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if and .Values.influxdbExternal.enabled (not .Values.influxdbExternal.tokenFromExistingSecret.enabled) }}
+        checksum/secrets-influxdb-external: {{ include (print $.Template.BasePath "/secrets-influxdb-external.yaml") . | sha256sum }}
+        {{- end }}
+{{- if .Values.api.podAnnotations }}
+{{ toYaml .Values.api.podAnnotations | nindent 8 }}
+{{- end }}
       labels:
         {{- include "flagsmith.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: api
@@ -81,6 +87,36 @@ spec:
           value: {{ template "flagsmith.postgres.hostname" . }}
         - name: DATABASE_URL
           value: postgres://{{.Values.postgresql.postgresqlUsername}}:{{ .Values.postgresql.postgresqlPassword}}@{{ template "flagsmith.postgres.hostname" . }}:5432/{{ .Values.postgresql.postgresqlDatabase}}
+{{- if .Values.influxdb.enabled }}
+        - name: INFLUXDB_URL
+          value: http://{{- template "flagsmith.influx.hostname" -}}:8086
+        - name: INFLUXDB_BUCKET
+          value: {{ .Values.influxdb.adminUser.bucket }}
+        - name: INFLUXDB_ORG
+          value: {{ .Values.influxdb.adminUser.organization }}
+        - name: INFLUXDB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "influxdb.fullname" . }}-auth
+              key: admin-token
+{{- else if .Values.influxdbExternal.enabled }}
+        - name: INFLUXDB_URL
+          value: {{ .Values.influxdbExternal.url | required "Must specify a URL for an external InfluxDB" }}
+        - name: INFLUXDB_BUCKET
+          value: {{ .Values.influxdbExternal.bucket | required "Must specify a bucket for an external InfluxDB" }}
+        - name: INFLUXDB_ORG
+          value: {{ .Values.influxdbExternal.organization | required "Must specify an organization for an external InfluxDB" }}
+        - name: INFLUXDB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              {{- if .Values.influxdbExternal.tokenFromExistingSecret.enabled }}
+              name: {{ .Values.influxdbExternal.tokenFromExistingSecret.name | required "Must set secret name for external InfluxDB secret" }}
+              key: {{ .Values.influxdbExternal.tokenFromExistingSecret.key | required "Must set key for external InfluxDB secret" }}
+              {{- else }}
+              name: {{ template "influxdb.fullname" . }}-external-auth
+              key: admin-token
+              {{- end }}
+{{- end }}
           
 {{- if .Values.api.env }}
 {{ toYaml .Values.api.env | indent 8 }}

--- a/charts/flagsmith/templates/persistance-volume-claim-influxdb.yaml
+++ b/charts/flagsmith/templates/persistance-volume-claim-influxdb.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.influxdb.enabled }}
 {{- if and (.Values.influxdb.persistence.enabled) (not .Values.influxdb.persistence.useExisting) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -16,6 +17,7 @@ spec:
   storageClassName: ""
 {{- else }}
   storageClassName: "{{ .Values.influxdb.persistence.storageClass }}"
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/flagsmith/templates/secrets-influxdb-external.yaml
+++ b/charts/flagsmith/templates/secrets-influxdb-external.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.influxdbExternal.enabled (not .Values.influxdbExternal.tokenFromExistingSecret.enabled) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    {{- include "influxdb.labels" . | nindent 4 }}
+  name: {{ template "influxdb.fullname" . }}-external-auth
+data:
+  admin-token: {{ .Values.influxdbExternal.token | b64enc | quote }}
+{{- end }}

--- a/charts/flagsmith/templates/secrets-influxdb.yaml
+++ b/charts/flagsmith/templates/secrets-influxdb.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.influxdb.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,13 +7,13 @@ metadata:
   name: {{ template "influxdb.fullname" . }}-auth
 data:
   {{- if .Values.influxdb.adminUser.token }}
-  admin-token: {{ .Values.influxdb.adminUser.token  | b64enc | quote }}
+  admin-token: {{ .Values.influxdb.adminUser.token | b64enc | quote }}
   {{- else }}
   admin-token: {{ randAlphaNum 32 | b64enc | quote }}
   {{- end }}
-
   {{- if .Values.influxdb.adminUser.password }}
   admin-password: {{ .Values.influxdb.adminUser.password | b64enc | quote }}
   {{- else }}
   admin-password: {{ randAlphaNum 32 | b64enc | quote }}
   {{- end }}
+{{- end }}

--- a/charts/flagsmith/templates/service-influxdb.yaml
+++ b/charts/flagsmith/templates/service-influxdb.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.influxdb.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -11,3 +12,4 @@ spec:
       protocol: TCP
       name: http
   selector: {{- include "influxdb.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/flagsmith/templates/statefulset-influxdb.yaml
+++ b/charts/flagsmith/templates/statefulset-influxdb.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.influxdb.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -64,3 +65,4 @@ spec:
       tolerations:
         {{ toYaml . | nindent 8 | trim }}
       {{- end }}
+{{- end }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -88,6 +88,7 @@ postgresql:
     postgresqlPassword: flagsmith
 
 influxdb:
+    enabled: true
     nameOverride: influxdb
     image:
         repository: quay.io/influxdb/influxdb
@@ -112,6 +113,17 @@ influxdb:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+
+influxdbExternal:
+    enabled: false
+    url: null
+    bucket: null
+    organization: null
+    token: null
+    tokenFromExistingSecret:
+        enabled: false
+        name: null
+        key: null
 
 hooks:
     enabled: false


### PR DESCRIPTION
Set env-vars in the API deployment to connect to InfluxDB.

Also allows InfluxDB to be turned off.

Also allows retrieving the InfluxDB token from an existing k8s secret.

Some implementation notes:
- Also sets annotations on the API pods so they get cycled when the InfluxDB config they reference changes
    - Though this doesn't work for an external k8s secret, pods would need to be manually cycled in that case
- Have kept the config for the external InfluxDB separated from the internal. I'm a bit torn, but I don't think it makes heaps of difference really.