### PR TITLE
Lint utility: tidy generated charts directories

### DIFF
--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -1,3 +1,5 @@
 #!/bin/bash -ex
 
 docker run --rm -it -v $(pwd):/repo --workdir /repo quay.io/helmpack/chart-testing ct lint --config ct.yaml "$@"
+# Tidy up any generated sub-charts directories, which will be owned by root because of the docker container
+docker run --rm -it -v $(pwd):/repo --workdir /repo quay.io/helmpack/chart-testing sh -c 'rm -rf charts/**/charts'


### PR DESCRIPTION
Using docker to run the local-linting means that any files it writes are owned by root. In particular, any sub-charts directories. This tidies those generated directories away.