### PR TITLE
Lint utility: even more thorough tidying

### DIFF
--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -1,5 +1,15 @@
 #!/bin/bash -ex
 
-docker run --rm -it -v $(pwd):/repo --workdir /repo quay.io/helmpack/chart-testing ct lint --config ct.yaml "$@"
-# Tidy up any generated sub-charts directories, which will be owned by root because of the docker container
-docker run --rm -it -v $(pwd):/repo --workdir /repo quay.io/helmpack/chart-testing sh -c 'rm -rf charts/**/charts'
+cleanup() {
+    # Tidy up any generated sub-charts directories, which will be owned by root because of the docker container
+    echo "CLEANING UP"
+    docker run --rm -it -v $(pwd):/repo --workdir /repo quay.io/helmpack/chart-testing sh -c 'rm -rf charts/**/charts && rm -rf charts/**/tmpcharts'
+}
+
+main() {
+    trap cleanup EXIT
+    cleanup
+    docker run --rm -it -v $(pwd):/repo --workdir /repo quay.io/helmpack/chart-testing ct lint --config ct.yaml "$@"
+}
+
+main "$@"


### PR DESCRIPTION
Cleanup any sub-charts and any sub-tmpcharts directories. And do this before linting, and after linting, even if linting fails.