### PR TITLE
Fix InfluxDB env-vars

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: 2.6.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/_helpers.tpl
+++ b/charts/flagsmith/templates/_helpers.tpl
@@ -167,7 +167,7 @@ Postgres hostname
 Influxdb hostname
 */}}
 {{- define "flagsmith.influx.hostname" -}}
-{{- printf "%s-%s" .Release.Name .Values.influx.nameOverride -}}.{{ .Release.Namespace }}.svc.cluster.local
+{{ template "influxdb.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 {{- end -}}
 
 {{/*

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -89,7 +89,7 @@ spec:
           value: postgres://{{.Values.postgresql.postgresqlUsername}}:{{ .Values.postgresql.postgresqlPassword}}@{{ template "flagsmith.postgres.hostname" . }}:5432/{{ .Values.postgresql.postgresqlDatabase}}
 {{- if .Values.influxdb.enabled }}
         - name: INFLUXDB_URL
-          value: http://{{- template "flagsmith.influx.hostname" -}}:8086
+          value: http://{{- template "flagsmith.influx.hostname" . -}}:8086
         - name: INFLUXDB_BUCKET
           value: {{ .Values.influxdb.adminUser.bucket }}
         - name: INFLUXDB_ORG


### PR DESCRIPTION
Fix so that the chart-managed InfluxDB uses the correct hostname in the URL.