### PR TITLE
More PostgreSQL and database options

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.2.3
+version: 0.2.4
 appVersion: 2.6.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/README.md
+++ b/charts/flagsmith/README.md
@@ -110,13 +110,41 @@ Then access `http://localhost:8080` in a browser.
 By default, the chart creates its own PostgreSQL server within the cluster.
 
 To connect the Flagsmith API to an external PostgreSQL server set the
-environment variable:
+values under `databaseExternal`, eg:
 
-* `DATABASE_URL`: should be a standard format database url
-e.g. postgres://user:password@host:port/db_name
+```yaml
+postgresql:
+  enabled: false  # turn off the chart-managed postgres
 
-There are more details on environment variables within the
-[API readme](https://github.com/Flagsmith/flagsmith-api/blob/master/readme.md)
+databaseExternal:
+  enabled: true
+  # Can specify the full URL
+  url: 'postgres://myuser:mypass@myhost:5432/mydbname'
+  # Or can specify each part (url takes precedence if set)
+  type: postgres
+  host: myhost
+  port: 5432
+  database: mydbname
+  username: myuser
+  password: mypass
+  # Or can specify a pre-existing k8s secret containing the database URL
+  urlFromExistingSecret:
+    enabled: true
+    name: my-precreated-db-config
+    key: DB_URL
+```
+
+### Environment variables
+
+The chart handles most environment variables required, but see the
+[API readme](https://github.com/Flagsmith/flagsmith-api/blob/master/readme.md#environment-variables)
+for all available configuration options. These can be set using `api.extraEnv`, eg:
+
+```yaml
+api:
+  extraEnv:
+    LOG_LEVEL: DEBUG
+```
 
 ### Resource allocation
 
@@ -149,101 +177,111 @@ Currently this is used to measure:
 The following table lists the configurable parameters of the chart and
 their default values.
 
-| Parameter                                          | Description                                                   | Default                        |
-| ---------                                          | ------------                                                  | -------                        |
-| `api.image.repository`                             | docker image repository for flagsmith api                     | `flagsmith/flagsmith-api`      |
-| `api.image.tag`                                    | docker image tag for flagsmith api                            | appVersion                     |
-| `api.image.imagePullPolicy`                        |                                                               | `IfNotPresent`                 |
-| `api.image.imagePullSecrets`                       |                                                               | `[]`                           |
-| `api.replicacount`                                 | number of replicas for the flagsmith api                      | 1                              |
-| `api.resources`                                    | resources per pod for the flagsmith api                       | `{}`                           |
-| `api.podLabels`                                    | additional labels to apply to pods for the flagsmith api      | `{}`                           |
-| `api.extraEnv`                                     | extra environment variables to set for the flagsmith api      | `{}`                           |
-| `api.nodeSelector`                                 |                                                               | `{}`                           |
-| `api.tolerations`                                  |                                                               | `[]`                           |
-| `api.affinity`                                     |                                                               | `{}`                           |
-| `api.livenessProbe.failureThreshold`               |                                                               | 5                              |
-| `api.livenessProbe.initialDelaySeconds`            |                                                               | 10                             |
-| `api.livenessProbe.periodSeconds`                  |                                                               | 10                             |
-| `api.livenessProbe.successThreshold`               |                                                               | 1                              |
-| `api.livenessProbe.timeoutSeconds`                 |                                                               | 2                              |
-| `api.readinessProbe.failureThreshold`              |                                                               | 10                             |
-| `api.readinessProbe.initialDelaySeconds`           |                                                               | 10                             |
-| `api.readinessProbe.periodSeconds`                 |                                                               | 10                             |
-| `api.readinessProbe.successThreshold`              |                                                               | 1                              |
-| `api.readinessProbe.timeoutSeconds`                |                                                               | 2                              |
-| `api.dbWaiter.image.repository`                    |                                                               | `willwill/wait-for-it`         |
-| `api.dbWaiter.image.tag`                           |                                                               | `latest`                       |
-| `api.dbWaiter.image.imagePullPolicy`               |                                                               | `IfNotPresent`                 |
-| `api.dbWaiter.timeoutSeconds`                      | Time before init container will retry                         | 30                             |
-| `frontend.enabled`                                 | Whether the flagsmith frontend is enabled                     | `true`                         |
-| `frontend.image.repository`                        | docker image repository for flagsmith frontend                | `flagsmith/flagsmith-frontend` |
-| `frontend.image.tag`                               | docker image tag for flagsmith frontend                       | appVersion                     |
-| `frontend.image.imagePullPolicy`                   |                                                               | `IfNotPresent`                 |
-| `frontend.image.imagePullSecrets`                  |                                                               | `[]`                           |
-| `frontend.replicacount`                            | number of replicas for the flagsmith frontend                 | 1                              |
-| `frontend.resources`                               | resources per pod for the flagsmith frontend                  | `{}`                           |
-| `frontend.extraEnv`                                | extra environment variables to set for the flagsmith frontend | `{}`                           |
-| `frontend.nodeSelector`                            |                                                               | `{}`                           |
-| `frontend.tolerations`                             |                                                               | `[]`                           |
-| `frontend.affinity`                                |                                                               | `{}`                           |
-| `frontend.livenessProbe.failureThreshold`          |                                                               | 20                             |
-| `frontend.livenessProbe.initialDelaySeconds`       |                                                               | 20                             |
-| `frontend.livenessProbe.periodSeconds`             |                                                               | 10                             |
-| `frontend.livenessProbe.successThreshold`          |                                                               | 1                              |
-| `frontend.livenessProbe.timeoutSeconds`            |                                                               | 10                             |
-| `frontend.readinessProbe.failureThreshold`         |                                                               | 20                             |
-| `frontend.readinessProbe.initialDelaySeconds`      |                                                               | 20                             |
-| `frontend.readinessProbe.periodSeconds`            |                                                               | 10                             |
-| `frontend.readinessProbe.successThreshold`         |                                                               | 1                              |
-| `frontend.readinessProbe.timeoutSeconds`           |                                                               | 10                             |
-| `postgresql.enabled`                               | if `true`, creates in-cluster PostgreSQL database             | `true`                         |
-| `postgresql.serviceAccount.enabled`                | creates a serviceaccount for the postgres pod                 | `true`                         |
-| `nameOverride`                                     |                                                               | `flagsmith-postgres`           |
-| `postgresqlDatabase`                               |                                                               | `flagsmith`                    |
-| `postgresqlUsername`                               |                                                               | `postgres`                     |
-| `postgresqlPassword`                               |                                                               | `flagsmith`                    |
-| `influxdb.enabled`                                 |                                                               | `true`                         |
-| `influxdb.nameOverride`                            |                                                               | `influxdb`                     |
-| `influxdb.image.repository`                        | docker image repository for influxdb                          | `quay.io/influxdb/influxdb`    |
-| `influxdb.image.tag`                               | docker image tag for influxdb                                 | `v2.0.2`                       |
-| `influxdb.image.imagePullPolicy`                   |                                                               | `IfNotPresent`                 |
-| `influxdb.image.imagePullSecrets`                  |                                                               | `[]`                           |
-| `influxdb.adminUser.organization`                  |                                                               | `influxdata`                   |
-| `influxdb.adminUser.bucket`                        |                                                               | `default`                      |
-| `influxdb.adminUser.user`                          |                                                               | `admin`                        |
-| `influxdb.adminUser.password`                      |                                                               | randomly generated             |
-| `influxdb.adminUser.token`                         |                                                               | randomly generated             |
-| `influxdb.persistence.enabled`                     |                                                               | `false`                        |
-| `influxdb.resources`                               | resources per pod for the influxdb                            | `{}`                           |
-| `influxdb.nodeSelector`                            |                                                               | `{}`                           |
-| `influxdb.tolerations`                             |                                                               | `[]`                           |
-| `influxdb.affinity`                                |                                                               | `{}`                           |
-| `influxdbExternal.enabled`                         | Use an InfluxDB not managed by this chart                     | `false`                        |
-| `influxdbExternal.url`                             |                                                               |                                |
-| `influxdbExternal.bucket`                          |                                                               |                                |
-| `influxdbExternal.organization`                    |                                                               |                                |
-| `influxdbExternal.token`                           |                                                               |                                |
-| `influxdbExternal.tokenFromExistingSecret.enabled` | Use reference to a k8s secret not managed by this chart       | `false`                        |
-| `influxdbExternal.tokenFromExistingSecret.name`    | Referenced secret name                                        |                                |
-| `influxdbExternal.tokenFromExistingSecret.key`     | Key within the referenced secret to use                       |                                |
-| `hooks.enabled`                                    | Enables hooks (to migrate the db)                             | `false`                        |
-| `hooks.removeOnSuccess`                            |                                                               | `true`                         |
-| `service.influxdb.externalPort`                    |                                                               | `8080`                         |
-| `service.api.type`                                 |                                                               | `ClusterIP`                    |
-| `service.api.port`                                 |                                                               | `8000`                         |
-| `service.frontend.type`                            |                                                               | `ClusterIP`                    |
-| `service.frontend.port`                            |                                                               | `8080`                         |
-| `ingress.frontend.enabled`                         |                                                               | `false`                        |
-| `ingress.frontend.annotations`                     |                                                               | `{}`                           |
-| `ingress.frontend.hosts[].host`                    |                                                               | `chart-example.local`          |
-| `ingress.frontend.hosts[].paths`                   |                                                               | `[]`                           |
-| `ingress.frontend.tls`                             |                                                               | `[]`                           |
-| `ingress.api.enabled`                              |                                                               | `false`                        |
-| `ingress.api.annotations`                          |                                                               | `{}`                           |
-| `ingress.api.hosts[].host`                         |                                                               | `chart-example.local`          |
-| `ingress.api.hosts[].paths`                        |                                                               | `[]`                           |
-| `ingress.api.tls`                                  |                                                               | `[]`                           |
+| Parameter                                          | Description                                                    | Default                        |
+| ---------                                          | ------------                                                   | -------                        |
+| `api.image.repository`                             | docker image repository for flagsmith api                      | `flagsmith/flagsmith-api`      |
+| `api.image.tag`                                    | docker image tag for flagsmith api                             | appVersion                     |
+| `api.image.imagePullPolicy`                        |                                                                | `IfNotPresent`                 |
+| `api.image.imagePullSecrets`                       |                                                                | `[]`                           |
+| `api.replicacount`                                 | number of replicas for the flagsmith api                       | 1                              |
+| `api.resources`                                    | resources per pod for the flagsmith api                        | `{}`                           |
+| `api.podLabels`                                    | additional labels to apply to pods for the flagsmith api       | `{}`                           |
+| `api.extraEnv`                                     | extra environment variables to set for the flagsmith api       | `{}`                           |
+| `api.nodeSelector`                                 |                                                                | `{}`                           |
+| `api.tolerations`                                  |                                                                | `[]`                           |
+| `api.affinity`                                     |                                                                | `{}`                           |
+| `api.livenessProbe.failureThreshold`               |                                                                | 5                              |
+| `api.livenessProbe.initialDelaySeconds`            |                                                                | 10                             |
+| `api.livenessProbe.periodSeconds`                  |                                                                | 10                             |
+| `api.livenessProbe.successThreshold`               |                                                                | 1                              |
+| `api.livenessProbe.timeoutSeconds`                 |                                                                | 2                              |
+| `api.readinessProbe.failureThreshold`              |                                                                | 10                             |
+| `api.readinessProbe.initialDelaySeconds`           |                                                                | 10                             |
+| `api.readinessProbe.periodSeconds`                 |                                                                | 10                             |
+| `api.readinessProbe.successThreshold`              |                                                                | 1                              |
+| `api.readinessProbe.timeoutSeconds`                |                                                                | 2                              |
+| `api.dbWaiter.image.repository`                    |                                                                | `willwill/wait-for-it`         |
+| `api.dbWaiter.image.tag`                           |                                                                | `latest`                       |
+| `api.dbWaiter.image.imagePullPolicy`               |                                                                | `IfNotPresent`                 |
+| `api.dbWaiter.timeoutSeconds`                      | Time before init container will retry                          | 30                             |
+| `frontend.enabled`                                 | Whether the flagsmith frontend is enabled                      | `true`                         |
+| `frontend.image.repository`                        | docker image repository for flagsmith frontend                 | `flagsmith/flagsmith-frontend` |
+| `frontend.image.tag`                               | docker image tag for flagsmith frontend                        | appVersion                     |
+| `frontend.image.imagePullPolicy`                   |                                                                | `IfNotPresent`                 |
+| `frontend.image.imagePullSecrets`                  |                                                                | `[]`                           |
+| `frontend.replicacount`                            | number of replicas for the flagsmith frontend                  | 1                              |
+| `frontend.resources`                               | resources per pod for the flagsmith frontend                   | `{}`                           |
+| `frontend.extraEnv`                                | extra environment variables to set for the flagsmith frontend  | `{}`                           |
+| `frontend.nodeSelector`                            |                                                                | `{}`                           |
+| `frontend.tolerations`                             |                                                                | `[]`                           |
+| `frontend.affinity`                                |                                                                | `{}`                           |
+| `frontend.livenessProbe.failureThreshold`          |                                                                | 20                             |
+| `frontend.livenessProbe.initialDelaySeconds`       |                                                                | 20                             |
+| `frontend.livenessProbe.periodSeconds`             |                                                                | 10                             |
+| `frontend.livenessProbe.successThreshold`          |                                                                | 1                              |
+| `frontend.livenessProbe.timeoutSeconds`            |                                                                | 10                             |
+| `frontend.readinessProbe.failureThreshold`         |                                                                | 20                             |
+| `frontend.readinessProbe.initialDelaySeconds`      |                                                                | 20                             |
+| `frontend.readinessProbe.periodSeconds`            |                                                                | 10                             |
+| `frontend.readinessProbe.successThreshold`         |                                                                | 1                              |
+| `frontend.readinessProbe.timeoutSeconds`           |                                                                | 10                             |
+| `postgresql.enabled`                               | if `true`, creates in-cluster PostgreSQL database              | `true`                         |
+| `postgresql.serviceAccount.enabled`                | creates a serviceaccount for the postgres pod                  | `true`                         |
+| `nameOverride`                                     |                                                                | `flagsmith-postgres`           |
+| `postgresqlDatabase`                               |                                                                | `flagsmith`                    |
+| `postgresqlUsername`                               |                                                                | `postgres`                     |
+| `postgresqlPassword`                               |                                                                | `flagsmith`                    |
+| `databaseExternal.enabled`                         | use an external database. Specify database URL, or all parts.  | `false`                        |
+| `databaseExternal.url`                             | See https://github.com/kennethreitz/dj-database-url#url-schema |                                |
+| `databaseExternal.type`                            | Note: Only postgres supported by default images.               | `postgres`                     |
+| `databaseExternal.port`                            |                                                                | 5432                           |
+| `databaseExternal.database`                        | Name of the database within the server                         |                                |
+| `databaseExternal.username`                        |                                                                |                                |
+| `databaseExternal.password`                        |                                                                |                                |
+| `databaseExternal.urlFromExistingSecret.enabled`   | Reference an existing secret containing the database URL       |                                |
+| `databaseExternal.name`                            | Name of referenced secret                                      |                                |
+| `databaseExternal.key`                             | Key within the referenced secrt to use                         |                                |
+| `influxdb.enabled`                                 |                                                                | `true`                         |
+| `influxdb.nameOverride`                            |                                                                | `influxdb`                     |
+| `influxdb.image.repository`                        | docker image repository for influxdb                           | `quay.io/influxdb/influxdb`    |
+| `influxdb.image.tag`                               | docker image tag for influxdb                                  | `v2.0.2`                       |
+| `influxdb.image.imagePullPolicy`                   |                                                                | `IfNotPresent`                 |
+| `influxdb.image.imagePullSecrets`                  |                                                                | `[]`                           |
+| `influxdb.adminUser.organization`                  |                                                                | `influxdata`                   |
+| `influxdb.adminUser.bucket`                        |                                                                | `default`                      |
+| `influxdb.adminUser.user`                          |                                                                | `admin`                        |
+| `influxdb.adminUser.password`                      |                                                                | randomly generated             |
+| `influxdb.adminUser.token`                         |                                                                | randomly generated             |
+| `influxdb.persistence.enabled`                     |                                                                | `false`                        |
+| `influxdb.resources`                               | resources per pod for the influxdb                             | `{}`                           |
+| `influxdb.nodeSelector`                            |                                                                | `{}`                           |
+| `influxdb.tolerations`                             |                                                                | `[]`                           |
+| `influxdb.affinity`                                |                                                                | `{}`                           |
+| `influxdbExternal.enabled`                         | Use an InfluxDB not managed by this chart                      | `false`                        |
+| `influxdbExternal.url`                             |                                                                |                                |
+| `influxdbExternal.bucket`                          |                                                                |                                |
+| `influxdbExternal.organization`                    |                                                                |                                |
+| `influxdbExternal.token`                           |                                                                |                                |
+| `influxdbExternal.tokenFromExistingSecret.enabled` | Use reference to a k8s secret not managed by this chart        | `false`                        |
+| `influxdbExternal.tokenFromExistingSecret.name`    | Referenced secret name                                         |                                |
+| `influxdbExternal.tokenFromExistingSecret.key`     | Key within the referenced secret to use                        |                                |
+| `hooks.enabled`                                    | Enables hooks (to migrate the db)                              | `false`                        |
+| `hooks.removeOnSuccess`                            |                                                                | `true`                         |
+| `service.influxdb.externalPort`                    |                                                                | `8080`                         |
+| `service.api.type`                                 |                                                                | `ClusterIP`                    |
+| `service.api.port`                                 |                                                                | `8000`                         |
+| `service.frontend.type`                            |                                                                | `ClusterIP`                    |
+| `service.frontend.port`                            |                                                                | `8080`                         |
+| `ingress.frontend.enabled`                         |                                                                | `false`                        |
+| `ingress.frontend.annotations`                     |                                                                | `{}`                           |
+| `ingress.frontend.hosts[].host`                    |                                                                | `chart-example.local`          |
+| `ingress.frontend.hosts[].paths`                   |                                                                | `[]`                           |
+| `ingress.frontend.tls`                             |                                                                | `[]`                           |
+| `ingress.api.enabled`                              |                                                                | `false`                        |
+| `ingress.api.annotations`                          |                                                                | `{}`                           |
+| `ingress.api.hosts[].host`                         |                                                                | `chart-example.local`          |
+| `ingress.api.hosts[].paths`                        |                                                                | `[]`                           |
+| `ingress.api.tls`                                  |                                                                | `[]`                           |
 
 ---
 

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/secrets-api: {{ include (print $.Template.BasePath "/secrets-api.yaml") . | sha256sum }}
         {{- if .Values.influxdb.enabled }}
         checksum/secrets-influxdb: {{ include (print $.Template.BasePath "/secrets-influxdb.yaml") . | sha256sum }}
         {{- end }}
@@ -66,27 +67,16 @@ spec:
         ports:
         - containerPort: {{ .Values.service.api.port }}
         env:
-        - name: DJANGO_DB_NAME
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "flagsmith.fullname" . }}
-              key: dbname
-        - name: DJANGO_DB_USER
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "flagsmith.fullname" . }}
-              key: dbuser
-        - name: DJANGO_DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "flagsmith.fullname" . }}
-              key: dbpassword
-        - name: DJANGO_DB_PORT
-          value: "5432"
-        - name: DJANGO_DB_HOST
-          value: {{ template "flagsmith.postgres.hostname" . }}
         - name: DATABASE_URL
-          value: postgres://{{.Values.postgresql.postgresqlUsername}}:{{ .Values.postgresql.postgresqlPassword}}@{{ template "flagsmith.postgres.hostname" . }}:5432/{{ .Values.postgresql.postgresqlDatabase}}
+          valueFrom:
+            secretKeyRef:
+              {{- if and .Values.databaseExternal.enabled .Values.databaseExternal.urlFromExistingSecret.enabled }}
+              name: {{ .Values.databaseExternal.urlFromExistingSecret.name }}
+              name: {{ .Values.databaseExternal.urlFromExistingSecret.key }}
+              {{- else }}
+              name: {{ template "flagsmith.fullname" . }}
+              key: DATABASE_URL
+              {{- end }}
 {{- if .Values.influxdb.enabled }}
         - name: INFLUXDB_URL
           value: http://{{- template "flagsmith.influx.hostname" . -}}:8086

--- a/charts/flagsmith/templates/secrets-api.yaml
+++ b/charts/flagsmith/templates/secrets-api.yaml
@@ -7,12 +7,16 @@ metadata:
     app.kubernetes.io/component: api
 type: Opaque
 data:
-  {{ if or (not .Values.postgresql.enabled) (.Values.postgresql.postgresqlUsername) }}
-  dbuser: {{ .Values.postgresql.postgresqlUsername | default "" | b64enc | quote }}
-  {{ end }}
-  {{ if or (not .Values.postgresql.enabled) (.Values.postgresql.postgresqlPassword) }}
-  dbpassword: {{ .Values.postgresql.postgresqlPassword | default "" | b64enc | quote }}
-  {{ end }}
-  {{ if or (not .Values.postgresql.enabled) (.Values.postgresql.postgresqlDatabase) }}
-  dbname: {{ .Values.postgresql.postgresqlDatabase | default "" | b64enc | quote }}
-  {{ end }}
+  {{- if .Values.databaseExternal.enabled }}
+  {{- with .Values.databaseExternal }}
+  {{- if not .urlFromExistingSecret.enabled }}
+  {{- if .url }}
+  DATABASE_URL: {{ .url | b64enc | quote }}
+  {{- else }}
+  DATABASE_URL: {{ (printf "%s://%s:%s@%s:%s/%s" (required "Must specify a database type" .type) (required "Must specify a database username" .username) (required "Must specify a database password" .password) (required "Must specify a database host" .host) (required "Must specify a database port" .port) (required "Must specify a database database name" .database) ) | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- else if .Values.postgresql.enabled }}
+  DATABASE_URL: {{ (printf "%s://%s:%s@%s:%s/%s" "postgres" (required "Must specify a postgres username" .Values.postgresql.postgresqlUsername) (required "Must specify a postgres password" .Values.postgresql.postgresqlPassword) (include "flagsmith.postgres.hostname" . ) "5432" (required "Must specify a postgres database name" .Values.postgresql.postgresqlDatabase) ) | b64enc | quote }}
+  {{- end }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -80,6 +80,20 @@ postgresql:
     postgresqlUsername: postgres
     postgresqlPassword: flagsmith
 
+databaseExternal:
+    enabled: false
+    url: null
+    type: postgres
+    host: null
+    port: 5432
+    database: null
+    username: null
+    password: null
+    urlFromExistingSecret:
+        enabled: false
+        name: null
+        key: null
+
 influxdb:
     enabled: true
     nameOverride: influxdb


### PR DESCRIPTION
- Always set `DATABASE_URL`, don't duplicate config to other DB-based env vars
- Allow setting config for an external database (be it PostgreSQL or otherwise)
- Allow referencing an existing secret that contains the database URL