### PR TITLE
Frontend proxy on by default

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.2.5
+version: 0.2.6
 appVersion: 2.6.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/NOTES.txt
+++ b/charts/flagsmith/templates/NOTES.txt
@@ -3,6 +3,12 @@
 See documentation at https://artifacthub.io/packages/helm/flagsmith/flagsmith/{{ .Chart.Version }}
 for more configuration options.
 
+To access Flagsmith using port-forwarding, run:
+
+kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "flagsmith.fullname" . }}-frontend 8080:{{ .Values.service.frontend.port }}
+
+Then access http://localhost:8080 in a browser.
+
 {{ if not (and .Values.ingress.frontend.enabled .Values.ingress.api.enabled) }}
 
 {{- $noIngressFor := (list) -}}

--- a/charts/flagsmith/templates/deployment-frontend.yaml
+++ b/charts/flagsmith/templates/deployment-frontend.yaml
@@ -50,11 +50,12 @@ spec:
         ports:
         - containerPort: {{ .Values.service.frontend.port }}
         env:
-        # TODO: Set the API URL to be the hostname of the API image above. Full url should be e.g. API_URL=http[s]://<api-hostname>/api/vi
-        - name: API_URL
-          value: '/api/v1/'
         - name: ASSET_URL
           value: '/'
+{{- if .Values.frontend.apiProxy.enabled }}
+        - name: PROXY_API_URL
+          value: http://{{ include "flagsmith.fullname" . }}-api.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.api.port }}
+{{- end }}
 {{- range $envName, $envValue := .Values.frontend.extraEnv }}
         - name: {{ $envName }}
           value: {{ $envValue | quote }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -54,6 +54,8 @@ frontend:
     # requests:
     #     cpu: 300m
     #     memory: 300Mi
+    apiProxy:
+        enabled: true
     extraEnv: {}
     nodeSelector: {}
     tolerations: []


### PR DESCRIPTION
Enable the frontend proxy by default and document.

And this allows for a really simple quick-start, so have documented that, and added steps to `NOTES.txt` that get shown to the user post-install so they know how to gain access.