### PR TITLE
Config for pod security context

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.2.9
+version: 0.2.10
 appVersion: 2.6.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/README.md
+++ b/charts/flagsmith/README.md
@@ -197,6 +197,8 @@ their default values.
 | `api.nodeSelector`                                 |                                                                | `{}`                           |
 | `api.tolerations`                                  |                                                                | `[]`                           |
 | `api.affinity`                                     |                                                                | `{}`                           |
+| `api.podSecurityContext`                           |                                                                | `{}`                           |
+| `api.defaultPodSecurityContext.enabled`            | whether to use the default security context                    | `true`                         |
 | `api.livenessProbe.failureThreshold`               |                                                                | 5                              |
 | `api.livenessProbe.initialDelaySeconds`            |                                                                | 10                             |
 | `api.livenessProbe.periodSeconds`                  |                                                                | 10                             |
@@ -223,6 +225,8 @@ their default values.
 | `frontend.nodeSelector`                            |                                                                | `{}`                           |
 | `frontend.tolerations`                             |                                                                | `[]`                           |
 | `frontend.affinity`                                |                                                                | `{}`                           |
+| `api.podSecurityContext`                           |                                                                | `{}`                           |
+| `api.defaultPodSecurityContext.enabled`            | whether to use the default security context                    | `true`                         |
 | `frontend.livenessProbe.failureThreshold`          |                                                                | 20                             |
 | `frontend.livenessProbe.initialDelaySeconds`       |                                                                | 20                             |
 | `frontend.livenessProbe.periodSeconds`             |                                                                | 10                             |

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -50,6 +50,12 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.api.image.imagePullSecrets | indent 4 }}
       {{- end }}
+      securityContext:
+        {{- $securityContext := .Values.api.podSecurityContext | default (dict) | deepCopy }}
+        {{- if .Values.api.defaultPodSecurityContext.enabled }}
+        {{- $securityContext = $securityContext | merge (omit .Values.api.defaultPodSecurityContext "enabled") }}
+        {{- end }}
+        {{- toYaml $securityContext | nindent 8 }}
       initContainers:
       - name: wait-for-db
         image: {{ .Values.api.dbWaiter.image.repository }}:{{ .Values.api.dbWaiter.image.tag }}

--- a/charts/flagsmith/templates/deployment-frontend.yaml
+++ b/charts/flagsmith/templates/deployment-frontend.yaml
@@ -43,6 +43,12 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.frontend.image.imagePullSecrets | indent 4 }}
       {{- end }}
+      securityContext:
+        {{- $securityContext := .Values.frontend.podSecurityContext | default (dict) | deepCopy }}
+        {{- if .Values.frontend.defaultPodSecurityContext.enabled }}
+        {{- $securityContext = $securityContext | merge (omit .Values.frontend.defaultPodSecurityContext "enabled") }}
+        {{- end }}
+        {{- toYaml $securityContext | nindent 8 }}
       containers:
       - name: {{ .Chart.Name }}-frontend
         image: {{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag | default (printf "v%s" .Chart.AppVersion) }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -18,6 +18,12 @@ api:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  podSecurityContext: {}
+  defaultPodSecurityContext:
+    enabled: true
+    # runAsNonRoot: true  # TODO: enable this, conditional on tag semver
+    # runAsUser: 1000
+    # runAsGroup: 1000
   livenessProbe:
     failureThreshold: 5
     initialDelaySeconds: 5
@@ -58,6 +64,12 @@ frontend:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  podSecurityContext: {}
+  defaultPodSecurityContext:
+    enabled: true
+    # runAsNonRoot: true  # TODO: enable this, conditional on tag semver
+    # runAsUser: 1000
+    # runAsGroup: 1000
   livenessProbe:
     failureThreshold: 20
     initialDelaySeconds: 20


### PR DESCRIPTION
I have made no effort to come up with the answers that will always be correct, because they depend on the cluster, but I think this is a sensible start.

As it stands, this doesn't actually apply any security context by default. Though I would like to be able to enable `runAsNonRoot`, because I think that is the one we are mostly likely to hit, and I suspect application changes to accommodate will be quite easy.