### PR TITLE
Don't wait for local Postgres service if configured to connect to external database

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.2.13
+version: 0.2.14
 appVersion: 2.6.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -57,6 +57,7 @@ spec:
         {{- end }}
         {{- toYaml $securityContext | nindent 8 }}
       initContainers:
+{{- if .Values.postgresql.enabled -}}
       - name: wait-for-db
         image: {{ .Values.api.dbWaiter.image.repository }}:{{ .Values.api.dbWaiter.image.tag }}
         imagePullPolicy: {{ .Values.api.dbWaiter.image.imagePullPolicy }}
@@ -65,6 +66,7 @@ spec:
           - --host={{ template "flagsmith.postgres.hostname" . }}
           - --port=5432
           - --timeout={{ .Values.api.dbWaiter.timeoutSeconds }}
+{{- end -}}
       - name: migrate-db
         image: {{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default (printf "v%s" .Chart.AppVersion) }}
         imagePullPolicy: {{ .Values.api.image.imagePullPolicy }}

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -57,7 +57,7 @@ spec:
         {{- end }}
         {{- toYaml $securityContext | nindent 8 }}
       initContainers:
-{{- if .Values.postgresql.enabled -}}
+{{- if eq .Values.databaseExternal.enabled false }}
       - name: wait-for-db
         image: {{ .Values.api.dbWaiter.image.repository }}:{{ .Values.api.dbWaiter.image.tag }}
         imagePullPolicy: {{ .Values.api.dbWaiter.image.imagePullPolicy }}
@@ -66,7 +66,7 @@ spec:
           - --host={{ template "flagsmith.postgres.hostname" . }}
           - --port=5432
           - --timeout={{ .Values.api.dbWaiter.timeoutSeconds }}
-{{- end -}}
+{{- end }}
       - name: migrate-db
         image: {{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default (printf "v%s" .Chart.AppVersion) }}
         imagePullPolicy: {{ .Values.api.image.imagePullPolicy }}


### PR DESCRIPTION
Change proposal is to not wait for external database in flagsmith-api