### PR TITLE
fix affinity, nodeSelector and tolerations

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.2.19
+version: 0.2.20
 appVersion: "2.9"
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -33,15 +33,15 @@ spec:
     spec:
       {{- if .Values.api.affinity }}
       affinity:
-{{ toYaml .Values.api.affinity | indent 4 }}
+{{ toYaml .Values.api.affinity | indent 8 }}
       {{- end }}
       {{- if .Values.api.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.api.nodeSelector | indent 4 }}
+{{ toYaml .Values.api.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.api.tolerations }}
       tolerations:
-{{ toYaml .Values.api.tolerations | indent 4 }}
+{{ toYaml .Values.api.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.api.schedulerName }}
       schedulerName: "{{ .Values.api.schedulerName }}"

--- a/charts/flagsmith/templates/deployment-frontend.yaml
+++ b/charts/flagsmith/templates/deployment-frontend.yaml
@@ -26,15 +26,15 @@ spec:
     spec:
       {{- if .Values.frontend.affinity }}
       affinity:
-{{ toYaml .Values.frontend.affinity | indent 4 }}
+{{ toYaml .Values.frontend.affinity | indent 8 }}
       {{- end }}
       {{- if .Values.frontend.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.frontend.nodeSelector | indent 4 }}
+{{ toYaml .Values.frontend.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.frontend.tolerations }}
       tolerations:
-{{ toYaml .Values.frontend.tolerations | indent 4 }}
+{{ toYaml .Values.frontend.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.frontend.schedulerName }}
       schedulerName: "{{ .Values.frontend.schedulerName }}"


### PR DESCRIPTION
there is minimum version not working on `main` branch

```yaml
api:
  nodeSelector:
    kubernetes.io/arch: amd64
```

error:

```
Error: YAML parse error on flagsmith/templates/deployment-api.yaml: error converting YAML to JSON: yaml: line 31: mapping values are not allowed in this context
```

this PR contains working version