### PR TITLE
fix kubernetes version detection in ingress

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.2.20
+version: 0.2.21
 appVersion: "2.9"
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/ingress-api.yaml
+++ b/charts/flagsmith/templates/ingress-api.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.api.enabled -}}
 {{- $fullName := include "flagsmith.fullname" . -}}
 {{- $svcPort := .Values.service.api.port -}}
-{{- if semverCompare ">=1.18.0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
 {{- else -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -38,7 +38,7 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
-            {{- if semverCompare ">=1.18.0" $.Capabilities.KubeVersion.GitVersion }}
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
             backend:
               service:

--- a/charts/flagsmith/templates/ingress-api.yaml
+++ b/charts/flagsmith/templates/ingress-api.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.api.enabled -}}
 {{- $fullName := include "flagsmith.fullname" . -}}
 {{- $svcPort := .Values.service.api.port -}}
-{{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
 {{- else -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -38,7 +38,7 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
-            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
             backend:
               service:

--- a/charts/flagsmith/templates/ingress-frontend.yaml
+++ b/charts/flagsmith/templates/ingress-frontend.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.frontend.enabled -}}
 {{- $fullName := include "flagsmith.fullname" . -}}
 {{- $svcPort := .Values.service.frontend.port -}}
-{{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
 {{- else -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -38,7 +38,7 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
-            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
             backend:
               service:

--- a/charts/flagsmith/templates/ingress-frontend.yaml
+++ b/charts/flagsmith/templates/ingress-frontend.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.frontend.enabled -}}
 {{- $fullName := include "flagsmith.fullname" . -}}
 {{- $svcPort := .Values.service.frontend.port -}}
-{{- if semverCompare ">=1.18.0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
 {{- else -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -38,7 +38,7 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
-            {{- if semverCompare ">=1.18.0" $.Capabilities.KubeVersion.GitVersion }}
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
             backend:
               service:


### PR DESCRIPTION
`semverCompare ">=1.18.0" .Capabilities.KubeVersion.GitVersion` will work only for simple versions `v1.18.x` but not with extended versions `v1.15.12-eks-9fd540` (AWS EKS) replacing `>=1.18.0` with `>=1.18-0` fixies it.

also stable version of ingress is available from `1.19+` not `1.18+`. see https://v1-19.docs.kubernetes.io/docs/setup/release/notes/