### PR TITLE
Option to use the all-in-one Docker image

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.4.0
+version: 0.5.0
 appVersion: 2.9.4
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/deployment-frontend.yaml
+++ b/charts/flagsmith/templates/deployment-frontend.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.api.separateApiAndFrontend }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -90,3 +91,4 @@ spec:
           timeoutSeconds: {{ .Values.frontend.readinessProbe.timeoutSeconds }}
         resources:
 {{ toYaml .Values.frontend.resources | indent 10 }}
+{{- end }}

--- a/charts/flagsmith/templates/service-frontend.yaml
+++ b/charts/flagsmith/templates/service-frontend.yaml
@@ -9,8 +9,8 @@ spec:
   type: {{ .Values.service.frontend.type }}
   ports:
     - port: {{ .Values.service.frontend.port }}
-      targetPort: {{ .Values.service.frontend.port }}
+      targetPort: {{ .Values.api.separateApiAndFrontend | ternary .Values.service.frontend.port .Values.service.api.port }}
       protocol: TCP
       name: http
   selector: {{- include "flagsmith.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: frontend
+    app.kubernetes.io/component: {{ if .Values.api.separateApiAndFrontend }}frontend{{ else }}api{{ end }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -4,6 +4,15 @@ api:
     tag: null  # defaults to .Chart.AppVersion
     imagePullPolicy: IfNotPresent
     imagePullSecrets: []
+  # Note that if setting this to false, need to set
+  # api.image.repository to flagsmith/flagsmith (or some other
+  # repository hosting the image with combined frontend and backend)
+  # and that the image tag exists (for flagsmith/flagsmith, >=2.10.0)
+  #
+  # Also, note that the ingress and service for the frontend remain
+  # (unless explicitly switched off), but both are handled by the api
+  # deployment's pods.
+  separateApiAndFrontend: true
   replicacount: 1
   podAnnotations: {}
   resources: {}


### PR DESCRIPTION
This is my attempt at a minimally disruptive way of supporting the all-in-one Docker image, https://hub.docker.com/r/flagsmith/flagsmith/.

Documented https://github.com/Flagsmith/flagsmith-docs/pull/44

Some notes:
- This just reuses the api deployment, but points the frontend service at it
    - So the service and ingress for the frontend remain (unless explicitly switched off)
- To use this, need to explicitly set the following:
    - `api.image.repository: flagsmith/flagsmith`
    - `api.separateApiAndFrontend: false`
    - `api.image.tag: 2.14` (or some other tag that exists in https://hub.docker.com/r/flagsmith/flagsmith/tags)

By default (ie, if `api.separateApiAndFrontend` is left at its default value of `true`) my changes here are a no-op, so this change will not break any existing installations.

At some point, may want to change the chart to use the all-in-one image by default (eg, change the default value of `api.separateApiAndFrontend` to `false`). This would be a breaking change and would warrant a major chart version bump. Would also want the default app version in `Chart.yaml` to be a tag that exists in https://hub.docker.com/r/flagsmith/flagsmith/. Would certainly want to allow time for testing of installations using the all-in-one image before doing this to find any issues.