### PR TITLE
Add ability to template annotations into flagsmith-api and flagsmith-frontend Services

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.6.0
+version: 0.7.0
 appVersion: 2.15.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/service-api.yaml
+++ b/charts/flagsmith/templates/service-api.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "flagsmith.fullname" . }}-api
+  {{- with .Values.service.api.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
     app.kubernetes.io/component: api

--- a/charts/flagsmith/templates/service-frontend.yaml
+++ b/charts/flagsmith/templates/service-frontend.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "flagsmith.fullname" . }}-frontend
+  {{- with .Values.service.api.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
     app.kubernetes.io/component: frontend

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -191,9 +191,11 @@ service:
   api:
     type: ClusterIP
     port: 8000
+    annotations: {}
   frontend:
     type: ClusterIP
     port: 8080
+    annotations: {}
 
 ingress:
   frontend:


### PR DESCRIPTION
Thanks for submitted a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version`

## Changes

This PR adds the ability to template annotations into the `flagsmith-api` and `flagsmith-frontend` Services. This was done so users could add their own annotations for any use case.

Closes #65

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

- Ran `tools/lint.sh` and ensured there were no errors
- Added a default `test: foo` annotation to both Services and ran a dry run to ensure they were applied as expected (which they were):
```shell
helm upgrade flagsmith ./charts/flagsmith --dry-run --debug --install --values ./charts/flagsmith/values.yaml
```
