### PR TITLE
Fix typo in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-Thanks for submitted a PR! Please check the boxes below:
+Thanks for submitting a PR! Please check the boxes below:
 
 - [ ] I have filled in the "Changes" section below?
 - [ ] I have filled in the "How did you test this code" section below?


### PR DESCRIPTION
I noticed the typo in

> Thanks for submitted a PR! Please check the boxes below:

So am fixing.