### PR TITLE
Issue 72: ingressClassName

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.7.3
+version: 0.8.0
 appVersion: 2.15.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/ingress-api.yaml
+++ b/charts/flagsmith/templates/ingress-api.yaml
@@ -21,6 +21,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- with .Values.ingress.api.ingressClassName }}
+  ingressClassName: {{ . }}
+{{- end }}
   {{- if .Values.ingress.api.tls }}
   tls:
     {{- range .Values.ingress.api.tls }}

--- a/charts/flagsmith/templates/ingress-frontend.yaml
+++ b/charts/flagsmith/templates/ingress-frontend.yaml
@@ -21,6 +21,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- with .Values.ingress.frontend.ingressClassName }}
+  ingressClassName: {{ . }}
+{{- end }}
   {{- if .Values.ingress.frontend.tls }}
   tls:
     {{- range .Values.ingress.frontend.tls }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -205,6 +205,7 @@ ingress:
   frontend:
     enabled: false
     annotations: {}
+    ingressClassName: null
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     hosts:
@@ -217,6 +218,7 @@ ingress:
   api:
     enabled: false
     annotations: {}
+    ingressClassName: null
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     hosts:


### PR DESCRIPTION
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version`

## Changes

Allow setting `ingressClassName` on the created ingress objects. Fixes #72.

Having looked at the following, have concluded this is set in the same place regardless of the API version for the ingress object:
```
$ kubectl explain ingress.spec.ingressClassName --api-version networking.k8s.io/v1
$ kubectl explain ingress.spec.ingressClassName --api-version networking.k8s.io/v1beta1
$ kubectl explain ingress.spec.ingressClassName --api-version extensions/v1beta1
```

Docs here https://github.com/Flagsmith/flagsmith-docs/pull/96

## How did you test this code?

Deployed to minikube and ran `helm diff` after setting a value for `ingress.api.ingressClassName` and `ingress.frontend.ingressClassName`.