### PR TITLE
Fix frontend.enabled switch

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.7.2
+version: 0.7.3
 appVersion: 2.15.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/deployment-frontend.yaml
+++ b/charts/flagsmith/templates/deployment-frontend.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.api.separateApiAndFrontend }}
+{{- if and .Values.api.separateApiAndFrontend .Values.frontend.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/flagsmith/templates/ingress-frontend.yaml
+++ b/charts/flagsmith/templates/ingress-frontend.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.frontend.enabled -}}
+{{- if and .Values.frontend.enabled .Values.ingress.frontend.enabled -}}
 {{- $fullName := include "flagsmith.fullname" . -}}
 {{- $svcPort := .Values.service.frontend.port -}}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -52,4 +52,4 @@ spec:
             {{- end }}
           {{- end }}
     {{- end }}
-  {{- end }}
+{{- end }}

--- a/charts/flagsmith/templates/service-frontend.yaml
+++ b/charts/flagsmith/templates/service-frontend.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.frontend.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,3 +19,4 @@ spec:
       name: http
   selector: {{- include "flagsmith.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: {{ if .Values.api.separateApiAndFrontend }}frontend{{ else }}api{{ end }}
+{{- end }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -53,6 +53,10 @@ api:
     timeoutSeconds: 30
 
 frontend:
+  # Set this to `false` to switch off the frontend (deployment,
+  # service and ingress). Set api.separateApiAndFrontend to false to
+  # switch off the deployment but retain the service and ingress
+  # pointing at the single Docker image that serves both.
   enabled: true
   image:
     repository: flagsmith/flagsmith-frontend


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version`

## Changes

Fixes #69 by honouring the `frontend.enabled` flag.

## How did you test this code?

Deployed to minikube. Set `frontend.enabled` to `false` and saw that the deployment, service and ingress for the frontend were removed.