### PR TITLE
Issue 40: e2e tests

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.9.1
+version: 0.9.2
 appVersion: 2.15.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/ci/e2e-test-values.yaml
+++ b/charts/flagsmith/ci/e2e-test-values.yaml
@@ -1,0 +1,9 @@
+_destructiveTests:
+  enabled: true
+api:
+  extraEnv:
+    EMAIL_BACKEND: 'django.core.mail.backends.console.EmailBackend'
+influxdb2:
+  # Needed to set this for the tests to not fail. Possibly related to
+  # https://github.com/Flagsmith/flagsmith/issues/340
+  enabled: false

--- a/charts/flagsmith/ci/e2e-test-values.yaml
+++ b/charts/flagsmith/ci/e2e-test-values.yaml
@@ -1,5 +1,7 @@
 _destructiveTests:
   enabled: true
+  e2eMonster:
+    useFirefox: true
 api:
   extraEnv:
     EMAIL_BACKEND: 'django.core.mail.backends.console.EmailBackend'

--- a/charts/flagsmith/templates/_api_environment.yaml
+++ b/charts/flagsmith/templates/_api_environment.yaml
@@ -55,3 +55,7 @@
 - name: USE_X_FORWARDED_HOST
   value: 'true'
 {{- end }}
+{{- if and .Values._destructiveTests.enabled .Values._destructiveTests.testToken }}
+- name: E2E_TEST_AUTH_TOKEN
+  value: {{ .Values._destructiveTests.testToken | quote }}
+{{- end }}

--- a/charts/flagsmith/templates/_helpers.tpl
+++ b/charts/flagsmith/templates/_helpers.tpl
@@ -203,6 +203,28 @@ Influxdb hostname
 {{- end -}}
 
 {{/*
+Frontend environment
+*/}}
+{{- define "flagsmith.frontend.environment" -}}
+- name: ASSET_URL
+  value: '/'
+{{- if .Values.frontend.apiProxy.enabled }}
+- name: PROXY_API_URL
+  value: http://{{ include "flagsmith.fullname" . }}-api.{{ .Release.Namespace }}:{{ .Values.service.api.port }}
+- name: FLAGSMITH_PROXY_API_URL
+  value: http://{{ include "flagsmith.fullname" . }}-api.{{ .Release.Namespace }}:{{ .Values.service.api.port }}
+{{- end }}
+{{- if and .Values._destructiveTests.enabled .Values._destructiveTests.testToken }}
+- name: E2E_TEST_TOKEN_PROD
+  value: {{ .Values._destructiveTests.testToken | quote }}
+{{- end }}
+{{- range $envName, $envValue := .Values.frontend.extraEnv }}
+- name: {{ $envName }}
+  value: {{ $envValue | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
 Database URL
 */}}
 {{- define "flagsmith.api.realDatabaseUrl" -}}

--- a/charts/flagsmith/templates/deployment-frontend.yaml
+++ b/charts/flagsmith/templates/deployment-frontend.yaml
@@ -56,19 +56,7 @@ spec:
         imagePullPolicy: {{ .Values.frontend.image.imagePullPolicy }}
         ports:
         - containerPort: {{ .Values.service.frontend.port }}
-        env:
-        - name: ASSET_URL
-          value: '/'
-{{- if .Values.frontend.apiProxy.enabled }}
-        - name: PROXY_API_URL
-          value: http://{{ include "flagsmith.fullname" . }}-api.{{ .Release.Namespace }}:{{ .Values.service.api.port }}
-        - name: FLAGSMITH_PROXY_API_URL
-          value: http://{{ include "flagsmith.fullname" . }}-api.{{ .Release.Namespace }}:{{ .Values.service.api.port }}
-{{- end }}
-{{- range $envName, $envValue := .Values.frontend.extraEnv }}
-        - name: {{ $envName }}
-          value: {{ $envValue | quote }}
-{{- end }}
+        env: {{- include "flagsmith.frontend.environment" . | nindent 8 }}
         livenessProbe:
           failureThreshold: {{ .Values.frontend.livenessProbe.failureThreshold }}
           httpGet:

--- a/charts/flagsmith/templates/tests/test-e2e-monster.yaml
+++ b/charts/flagsmith/templates/tests/test-e2e-monster.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.frontend.enabled }}
+{{- if and .Values._destructiveTests.enabled .Values._destructiveTests.e2eMonster.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ template "flagsmith.fullname" . }}-test-e2e-monster
+  labels:
+    {{- include "flagsmith.labels" . | nindent 4 }}
+    app.kubernetes.io/component: test-e2e
+  annotations:
+    "helm.sh/hook": test
+spec:
+{{- if .Values.api.image.imagePullSecrets }}
+  imagePullSecrets:
+{{ toYaml .Values.api.image.imagePullSecrets | indent 4 }}
+{{- end }}
+  initContainers:
+    - name: api
+      image: {{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default (printf "%s" .Chart.AppVersion) }}
+      imagePullPolicy: {{ .Values.api.image.imagePullPolicy }}
+      command:
+        - bash
+        - -c
+        - 'cp ./CI_COMMIT_SHA /git_commit_sha/commit_sha.txt'
+      volumeMounts:
+        - name: git-commit-sha
+          mountPath: /git_commit_sha/
+  containers:
+    - name: e2e
+      image: {{ .Values._destructiveTests.e2eMonster.image.repository }}:{{ .Values._destructiveTests.e2eMonster.image.tag }}
+      imagePullPolicy: {{ .Values.frontend.image.imagePullPolicy }}
+      command:
+        - bash
+        - -cex
+        - >-
+          apt -qq update &&
+          apt -qq install -y curl wget gpg git xvfb >> /dev/null &&
+          wget -qO - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/googlechrome-linux-keyring.gpg &&
+          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/googlechrome-linux-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" | tee /etc/apt/sources.list.d/google-chrome.list &&
+          apt -qq update &&
+          apt -qq install -y google-chrome-stable >> /dev/null &&
+          google-chrome --version &&
+          curl -fsSL https://deb.nodesource.com/setup_16.x | bash - &&
+          apt -qq install -y nodejs >> /dev/null &&
+          node --version &&
+          npm --version &&
+          git clone https://github.com/Flagsmith/flagsmith.git &&
+          TARGET_GIT_SHA="$(cat /git_commit_sha/commit_sha.txt)" &&
+          echo "TARGET_GIT_SHA=$TARGET_GIT_SHA" &&
+          (cd flagsmith &&
+          git checkout "$TARGET_GIT_SHA" &&
+          (cd frontend &&
+          export NODE_ENV=test &&
+          npm i &&
+          AUTH_TOKEN_PROJECT_NAME="$(node -e "console.log(require(\"./env/project_dev\").env.toUpperCase())")" &&
+          echo "AUTH_TOKEN_PROJECT_NAME=$AUTH_TOKEN_PROJECT_NAME" &&
+          eval "export E2E_TEST_TOKEN_$AUTH_TOKEN_PROJECT_NAME=$E2E_TEST_TOKEN_PROD" &&
+          env | grep E2E_ &&
+          npm run env &&
+          npm run test)) &&
+          echo "Tests ran successfully"
+
+      env: {{ include "flagsmith.frontend.environment" . | nindent 8 }}
+      resources: {{ .Values._destructiveTests.e2eMonster.resources | toYaml | nindent 8 }}
+      volumeMounts:
+        - name: git-commit-sha
+          mountPath: /git_commit_sha/
+          readOnly: true
+  restartPolicy: Never
+  volumes:
+    - name: git-commit-sha
+      emptyDir: {}
+{{- end }}
+{{- end }}

--- a/charts/flagsmith/templates/tests/test-e2e-monster.yaml
+++ b/charts/flagsmith/templates/tests/test-e2e-monster.yaml
@@ -35,11 +35,19 @@ spec:
         - >-
           apt -qq update &&
           apt -qq install -y curl wget gpg git xvfb >> /dev/null &&
+{{- if .Values._destructiveTests.e2eMonster.useFirefox }}
+          apt -qq install -y software-properties-common >> /dev/null &&
+          add-apt-repository ppa:mozillateam/ppa &&
+          (echo && echo 'Package: *' && echo 'Pin: release o=LP-PPA-mozillateam' && echo 'Pin-Priority: 1001' && echo) | tee /etc/apt/preferences.d/mozilla-firefox &&
+          apt -qq install -y firefox >> /dev/null &&
+          firefox --version &&
+{{- else }}
           wget -qO - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/googlechrome-linux-keyring.gpg &&
           echo "deb [arch=amd64 signed-by=/usr/share/keyrings/googlechrome-linux-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" | tee /etc/apt/sources.list.d/google-chrome.list &&
           apt -qq update &&
           apt -qq install -y google-chrome-stable >> /dev/null &&
           google-chrome --version &&
+{{- end }}
           curl -fsSL https://deb.nodesource.com/setup_16.x | bash - &&
           apt -qq install -y nodejs >> /dev/null &&
           node --version &&
@@ -50,6 +58,9 @@ spec:
           (cd flagsmith &&
           git checkout "$TARGET_GIT_SHA" &&
           (cd frontend &&
+{{- if .Values._destructiveTests.e2eMonster.useFirefox }}
+          sed -i 's/chrome/firefox/g' ./e2e/index.cafe.js ./.testcaferc.js &&
+{{- end }}
           export NODE_ENV=test &&
           npm i &&
           AUTH_TOKEN_PROJECT_NAME="$(node -e "console.log(require(\"./env/project_dev\").env.toUpperCase())")" &&

--- a/charts/flagsmith/templates/tests/test-e2e-monster.yaml
+++ b/charts/flagsmith/templates/tests/test-e2e-monster.yaml
@@ -61,7 +61,7 @@ spec:
 {{- if .Values._destructiveTests.e2eMonster.useFirefox }}
           sed -i 's/chrome/firefox/g' ./e2e/index.cafe.js ./.testcaferc.js &&
           sed -i '/other settings/a\ \ \ \ src: ["./e2e/cafe/environment.cafe.js", "./e2e/cafe/invite.cafe.js", "./e2e/cafe/project.cafe.js"],' .testcaferc.js &&
-          sed -i '/src.*e2e\/cafe/' ./e2e/index.cafe.js &&
+          sed -i '/src.*e2e\/cafe/d' ./e2e/index.cafe.js &&
 {{- end }}
           sed -i '/videoPath/d' ./.testcaferc.js &&
           sed -i 's/videoOptions/__videoOptions/' ./.testcaferc.js &&

--- a/charts/flagsmith/templates/tests/test-e2e-monster.yaml
+++ b/charts/flagsmith/templates/tests/test-e2e-monster.yaml
@@ -60,7 +60,7 @@ spec:
           (cd frontend &&
 {{- if .Values._destructiveTests.e2eMonster.useFirefox }}
           sed -i 's/chrome/firefox/g' ./e2e/index.cafe.js ./.testcaferc.js &&
-          sed -i '/other settings/a\ \ \ \ src: ["./e2e/cafe/environment.cafe.js", "./e2e/cafe/invite.cafe.js", "./e2e/cafe/project.cafe.js"],' .testcaferc.js &&
+          sed -i '/other settings/a\ \ \ \ src: ["./e2e/cafe/environment.cafe.js"],' .testcaferc.js &&
           sed -i '/src.*e2e\/cafe/d' ./e2e/index.cafe.js &&
           cat ./e2e/index.cafe.js &&
 {{- end }}

--- a/charts/flagsmith/templates/tests/test-e2e-monster.yaml
+++ b/charts/flagsmith/templates/tests/test-e2e-monster.yaml
@@ -62,6 +62,7 @@ spec:
           sed -i 's/chrome/firefox/g' ./e2e/index.cafe.js ./.testcaferc.js &&
           sed -i '/other settings/a\ \ \ \ src: ["./e2e/cafe/environment.cafe.js", "./e2e/cafe/invite.cafe.js", "./e2e/cafe/project.cafe.js"],' .testcaferc.js &&
           sed -i '/src.*e2e\/cafe/d' ./e2e/index.cafe.js &&
+          cat ./e2e/index.cafe.js &&
 {{- end }}
           sed -i '/videoPath/d' ./.testcaferc.js &&
           sed -i 's/videoOptions/__videoOptions/' ./.testcaferc.js &&

--- a/charts/flagsmith/templates/tests/test-e2e-monster.yaml
+++ b/charts/flagsmith/templates/tests/test-e2e-monster.yaml
@@ -60,8 +60,7 @@ spec:
           (cd frontend &&
 {{- if .Values._destructiveTests.e2eMonster.useFirefox }}
           sed -i 's/chrome/firefox/g' ./e2e/index.cafe.js ./.testcaferc.js &&
-          sed -i '/other settings/a\ \ \ \ src: ["./e2e/cafe/environment.cafe.js"],' .testcaferc.js &&
-          sed -i '/src.*e2e\/cafe/d' ./e2e/index.cafe.js &&
+          sed -i 's|e2e/cafe|e2e/cafe/environment.cafe.js|' ./e2e/index.cafe.js &&
           cat ./e2e/index.cafe.js &&
 {{- end }}
           sed -i '/videoPath/d' ./.testcaferc.js &&

--- a/charts/flagsmith/templates/tests/test-e2e-monster.yaml
+++ b/charts/flagsmith/templates/tests/test-e2e-monster.yaml
@@ -60,7 +60,13 @@ spec:
           (cd frontend &&
 {{- if .Values._destructiveTests.e2eMonster.useFirefox }}
           sed -i 's/chrome/firefox/g' ./e2e/index.cafe.js ./.testcaferc.js &&
+          sed -i '/other settings/a\ \ \ \ src: ["./e2e/cafe/environment.cafe.js", "./e2e/cafe/invite.cafe.js", "./e2e/cafe/project.cafe.js"],' .testcaferc.js &&
+          sed -i '/src.*e2e\/cafe/' ./e2e/index.cafe.js &&
 {{- end }}
+          sed -i '/videoPath/d' ./.testcaferc.js &&
+          sed -i 's/videoOptions/__videoOptions/' ./.testcaferc.js &&
+          sed -i 's/videoEncodingOptions/__videoEncodingOptions/' ./.testcaferc.js &&
+          cat ./.testcaferc.js &&
           export NODE_ENV=test &&
           npm i &&
           AUTH_TOKEN_PROJECT_NAME="$(node -e "console.log(require(\"./env/project_dev\").env.toUpperCase())")" &&

--- a/charts/flagsmith/templates/tests/test-e2e-monster.yaml
+++ b/charts/flagsmith/templates/tests/test-e2e-monster.yaml
@@ -60,7 +60,7 @@ spec:
           (cd frontend &&
 {{- if .Values._destructiveTests.e2eMonster.useFirefox }}
           sed -i 's/chrome/firefox/g' ./e2e/index.cafe.js ./.testcaferc.js &&
-          sed -i 's|e2e/cafe|e2e/cafe/{environment,invite.test,project}.cafe.js|' ./e2e/index.cafe.js &&
+          sed -i 's|concurrency([0-9]*)|concurrency(1)|' ./e2e/index.cafe.js &&
           cat ./e2e/index.cafe.js &&
 {{- end }}
           sed -i '/videoPath/d' ./.testcaferc.js &&

--- a/charts/flagsmith/templates/tests/test-e2e-monster.yaml
+++ b/charts/flagsmith/templates/tests/test-e2e-monster.yaml
@@ -60,7 +60,7 @@ spec:
           (cd frontend &&
 {{- if .Values._destructiveTests.e2eMonster.useFirefox }}
           sed -i 's/chrome/firefox/g' ./e2e/index.cafe.js ./.testcaferc.js &&
-          sed -i 's|e2e/cafe|e2e/cafe/environment.cafe.js|' ./e2e/index.cafe.js &&
+          sed -i 's|e2e/cafe|e2e/cafe/{environment,invite.test,project}.cafe.js|' ./e2e/index.cafe.js &&
           cat ./e2e/index.cafe.js &&
 {{- end }}
           sed -i '/videoPath/d' ./.testcaferc.js &&

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -261,6 +261,7 @@ _destructiveTests:
       repository: ubuntu
       tag: jammy
       imagePullPolicy: IfNotPresent
+    useFirefox: false
     resources:
       requests:
         memory: 1Gi

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -242,3 +242,25 @@ tests:
   frontend:
     enabled: true
     maxTime: 10
+
+# These are used for integration testing the chart and the
+# application. Enabling this will mean that data in a release is
+# destroyed or corrupted if the tests are run.
+_destructiveTests:
+  # A test is enabled if both this and the specific test is enabled
+  enabled: false
+  testToken: test-e2e-token
+  # This "monster" is in lieu of a specially constructed Docker image
+  # that contains the code and dependencies for running the e2e
+  # tests. It works by starting from a plain Ubuntu container,
+  # retrieving the commit SHA from the API container, then cloning the
+  # code from Github, installing dependencies, then running the tests.
+  e2eMonster:
+    enabled: true
+    image:
+      repository: ubuntu
+      tag: jammy
+      imagePullPolicy: IfNotPresent
+    resources:
+      requests:
+        memory: 1Gi

--- a/ct.yaml
+++ b/ct.yaml
@@ -3,3 +3,4 @@ chart-repos:
   - influxdata=https://helm.influxdata.com/
 target-branch: main
 validate-maintainers: false
+helm-extra-args: '--timeout 30m'


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version`

## Changes

Fixes #40.

This is my "monster" for running the E2E tests. I retrieves the git sha from the API container, then using a plain Ubuntu image, installs dependencies, clones the code from Github, then runs the tests.

## How did you test this code?

Waited for CI.

----

This is now passing CI, but with some caveats:
- The yucky work-out-the-git-sha-and-clone-from-github-etc-etc, which could be remedied by #86
- I've had to do some hacking to make it use firefox instead of chrome for it to run in Github actions. I'm not really sure why this made a difference. Debug logs from the test runner might help, but I'm mostly just confused by this. It ran with chrome locally, but not in Github. See #87
    - It would be nice if the e2e-testing image had both Firefox and Chrome installed for this reason, and if the browser(s?) to use could be configured in a nicer way than running `sed` over source files. Noted in #86
- I had to switch off influxdb for the tests to pass. This was the case locally too. I think this could point towards a real actual bug, not a test brittleness. See #88
- I had to hack `e2e/index.cafe.js` to run with concurrency of 1. I suspect this is because the Github action runner is CPU bound, so concurrency greater than 1 just means everything runs slower and the tests fall down.
    - It would be nice if this could be configured in a nicer way then running `sed` over source files. See #87