### PR TITLE
Add USE_X_FORWARDED_HOST setting

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.8.0
+version: 0.8.1
 appVersion: 2.15.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/_api_environment.yaml
+++ b/charts/flagsmith/templates/_api_environment.yaml
@@ -44,3 +44,7 @@
 - name: {{ $envName }}
   value: {{ $envValue | quote }}
 {{- end }}
+{{- if .Values.frontend.apiProxy.enabled }}
+- name: USE_X_FORWARDED_HOST
+  value: 'true'
+{{- end }}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version`

## Changes

Adds the USE_X_FORWARDED_HOST environment variable if using the apiProxy. 

This ensures that the API publishes obtains correct URL when using `request.build_absolute_uri`, for example when generating the entity_id and ACS URL in the SAML handshake. 

## How did you test this code?

Deployed the helm chart locally using minikube and ran `kubectl set env deployment/flagsmith-api --list` to confirm that the environment variable is set correctly. 

Fixes #80