### PR TITLE
Issue 79: set DJANGO_SECRET_KEY environment variable

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.8.0
+version: 0.9.0
 appVersion: 2.15.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/NOTES.txt
+++ b/charts/flagsmith/templates/NOTES.txt
@@ -24,3 +24,17 @@ for information about how to gain web access to the application.
 
 {{- end }}
 
+{{- if not .Values.api.secretKey }}
+
+######################################
+##### Warning: no secret key set #####
+######################################
+
+No secret key is set. For production systems, it is strongly
+recommended to generate a large random value and set it at
+`api.secretKey`. It must be kept secret.
+
+See https://docs.flagsmith.com/deployment/locally-api#creating-a-secret-key
+{{- end }}
+
+--------------------------------------

--- a/charts/flagsmith/templates/_api_environment.yaml
+++ b/charts/flagsmith/templates/_api_environment.yaml
@@ -8,6 +8,13 @@
       name: {{ template "flagsmith.fullname" . }}
       key: DATABASE_URL
       {{- end }}
+{{- if .Values.api.secretKey }}
+- name: DJANGO_SECRET_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ template "flagsmith.fullname" . }}
+      key: DJANGO_SECRET_KEY
+{{- end }}
 {{- if .Values.influxdb2.enabled }}
 - name: INFLUXDB_URL
   value: http://{{- template "flagsmith.influxdb.hostname" . -}}:80

--- a/charts/flagsmith/templates/secrets-api.yaml
+++ b/charts/flagsmith/templates/secrets-api.yaml
@@ -8,3 +8,6 @@ metadata:
 type: Opaque
 data:
   DATABASE_URL: {{ include "flagsmith.api.databaseUrl" . | trim | b64enc | quote }}
+{{- with .Values.api.secretKey }}
+  DJANGO_SECRET_KEY: {{ . | b64enc | quote }}
+{{- end }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -24,6 +24,8 @@ api:
   #   memory: 300Mi
   podLabels: {}
   extraEnv: {}
+  # See https://docs.flagsmith.com/deployment/locally-api#creating-a-secret-key
+  secretKey: null
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version`

## Changes

Allow the `DJANGO_SECRET_KEY` environment variable to be set for the API from the `api.secretKey` value in helm.

By default, this is set to nothing and falls back to existing behaviour. However, it prints a slight obnoxious message after doing deploying with helm to warn about it.

Helm really doesn't handle "generate a random string once and remember it" well at all, see https://helm.sh/docs/howto/charts_tips_and_tricks/#be-careful-with-generating-random-values. There are some workarounds, like https://stackoverflow.com/questions/56170052/how-not-to-overwrite-randomly-generated-secrets-in-helm-templates but I think by far the least surprising is what I have done here.

## How did you test this code?

Set `api.secretKey: abc123`, deployed, then, in an api pod, ran:
```
$ echo 'from django.conf import settings; print(settings.SECRET_KEY)' | /app/manage.py shell
abc123
```
So the env var is being set such that Django is finding it.