### PR TITLE
Neater output for the curl tests

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.10.1
+version: 0.10.2
 appVersion: 2.26.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/_helpers.tpl
+++ b/charts/flagsmith/templates/_helpers.tpl
@@ -270,3 +270,24 @@ Database URL for application
 {{ include "flagsmith.api.realDatabaseUrl" . }}
 {{- end }}
 {{- end }}
+
+{{/*
+Curl Test container
+*/}}
+{{- define "flagsmith.tests.curlContainer" -}}
+name: {{ .name }}
+image: curlimages/curl
+command: ['curl']
+args:
+  - --fail
+  - --max-time
+  - {{ .maxTime | squote }}
+  - --silent
+{{- if not .printResponseBody }}
+  - --output
+  - /dev/null
+{{- end }}
+  - --write-out
+  - 'URL: %{url_effective}\nHTTP status code: %{http_code}\nBytes downloaded: %{size_download}\nTime taken: %{time_total}s\n'
+  - {{ .url | squote }}
+{{- end }}

--- a/charts/flagsmith/templates/tests/test-api-http-health.yaml
+++ b/charts/flagsmith/templates/tests/test-api-http-health.yaml
@@ -10,13 +10,11 @@ metadata:
     "helm.sh/hook": test
 spec:
   containers:
-    - name: health
-      image: curlimages/curl
-      command: ['curl']
-      args:
-        - --fail
-        - --max-time
-        - {{ .Values.tests.api.maxTime | squote }}
-        - '{{ include "flagsmith.fullname" . }}-api:{{ .Values.service.api.port }}/health'
+    {{- $args := dict }}
+    {{- $_ := set $args "name" "api-health" }}
+    {{- $_ := set $args "maxTime" .Values.tests.api.maxTime }}
+    {{- $_ := set $args "printResponseBody" .Values.tests.api.printResponseBody }}
+    {{- $_ := set $args "url" (printf "%s-api:%d/health" (include "flagsmith.fullname" . ) (.Values.service.api.port | int64)) }}
+    - {{ include "flagsmith.tests.curlContainer" $args | nindent 6 }}
   restartPolicy: Never
 {{- end }}

--- a/charts/flagsmith/templates/tests/test-frontend-http.yaml
+++ b/charts/flagsmith/templates/tests/test-frontend-http.yaml
@@ -11,14 +11,12 @@ metadata:
     "helm.sh/hook": test
 spec:
   containers:
-    - name: index
-      image: curlimages/curl
-      command: ['curl']
-      args:
-        - --fail
-        - --max-time
-        - {{ .Values.tests.frontend.maxTime | squote }}
-        - '{{ include "flagsmith.fullname" . }}-frontend:{{ .Values.service.frontend.port }}'
+    {{- $args := dict }}
+    {{- $_ := set $args "name" "frontend" }}
+    {{- $_ := set $args "maxTime" .Values.tests.frontend.maxTime }}
+    {{- $_ := set $args "printResponseBody" .Values.tests.frontend.printResponseBody }}
+    {{- $_ := set $args "url" (printf "%s-frontend:%d" (include "flagsmith.fullname" . ) (.Values.service.frontend.port | int64)) }}
+    - {{ include "flagsmith.tests.curlContainer" $args | nindent 6 }}
   restartPolicy: Never
 {{- end }}
 {{- end }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -247,9 +247,11 @@ tests:
   api:
     enabled: true
     maxTime: 10
+    printResponseBody: false
   frontend:
     enabled: true
     maxTime: 10
+    printResponseBody: false
 
 # These are used for integration testing the chart and the
 # application. Enabling this will mean that data in a release is


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version`

## Changes

The curl tests I added in #77 wrote the output to stdout, which was lots of lines which were not very useful. Have added a flag to enable this, but default off. But it does still write some useful information from curl: the URL used, http status code, bytes downloaded, and time take.

## How did you test this code?

Waited for CI.