### PR TITLE
Issue 40: e2e tests with influxdb enabled

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.11.0
+version: 0.11.1
 appVersion: 2.26.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.10.2
+version: 0.11.0
 appVersion: 2.26.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/ci/e2e-test-values.yaml
+++ b/charts/flagsmith/ci/e2e-test-values.yaml
@@ -5,7 +5,8 @@ _destructiveTests:
 api:
   extraEnv:
     EMAIL_BACKEND: 'django.core.mail.backends.console.EmailBackend'
+    ENABLE_INFLUXDB_FEATURES: 'true'
+    FE_E2E_TEST_USER_EMAIL: 'nightwatch@solidstategroup.com'
+  influxdbEnsureSetup: true
 influxdb2:
-  # Needed to set this for the tests to not fail. Possibly related to
-  # https://github.com/Flagsmith/flagsmith/issues/340
-  enabled: false
+  enabled: true

--- a/charts/flagsmith/templates/_influxdb_setup.txt
+++ b/charts/flagsmith/templates/_influxdb_setup.txt
@@ -1,0 +1,132 @@
+# File extension is .txt not .py just because helm's linting complains
+# about non txt/tpl/yaml/yml extensions.
+
+import os
+import sys
+
+from influxdb_client import InfluxDBClient
+
+influxdb_url = os.environ["INFLUXDB_URL"]
+influxdb_token = os.environ["INFLUXDB_TOKEN"]
+influxdb_organization_name = os.environ["INFLUXDB_ORG"]
+influxdb_setup_ping_retries = int(os.environ.get("INFLUXDB_SETUP_PING_RETRIES", 30))
+influxdb_setup_ping_delay_seconds = int(os.environ.get("INFLUXDB_SETUP_PING_DELAY_SECONDS", 2))
+
+print("Configuring InfluxDB at {}".format(influxdb_url))
+
+client = InfluxDBClient(url=influxdb_url, token=influxdb_token)
+print("Checking for ping...")
+for attempt in range(1, influxdb_setup_ping_retries+1):
+    if client.ping():
+        break
+else:
+    print(f"Failed to ping after {influxdb_setup_ping_retries} retries (with {influxdb_setup_ping_delay_seconds}s delay between each retry)")
+    sys.exit(1)
+
+print("Successfully pinged influxdb")
+
+matching_organizations = client.organizations_api().find_organizations(org=influxdb_organization_name)
+
+if not matching_organizations:
+    print("No organizations found, not creating")
+    sys.exit(1)
+
+if len(matching_organizations) > 1:
+    print(f"Found multiple organizations with name {influxdb_organization_name}. This should not happen.")
+    sys.exit(1)
+
+organization = matching_organizations[0]
+
+buckets_to_ensure_exist = ["default", "default_downsampled_15m", "default_downsampled_1h"]
+buckets_api = client.buckets_api()
+print("Creating buckets if needed...")
+for bucket_name in buckets_to_ensure_exist:
+    existing_bucket = buckets_api.find_bucket_by_name(bucket_name)
+    if not existing_bucket:
+        print(f"Bucket {bucket_name} does not exist. Creating...")
+        buckets_api.create_bucket(bucket_name=bucket_name, org_id=organization.id)
+        print(f"Created bucket {bucket_name}.")
+    else:
+        print(f"Bucket {bucket_name} already exists. Nothing to do.")
+print("Finished creating buckets if needed.")
+
+
+tasks_to_ensure_exist = [{
+    "name": "Downsample (API Requests)",
+    "flux": """
+data = from(bucket: "default")
+    |> range(start: -duration(v: int(v: task.every) * 2))
+    |> filter(fn: (r) =>
+        (r._measurement == "api_call"))
+
+data
+    |> aggregateWindow(fn: sum, every: 15m)
+    |> filter(fn: (r) =>
+        (exists r._value))
+    |> to(bucket: "default_downsampled_15m")
+""",
+    "every": "15m",
+}, {
+    "name": "Downsample (Flag Evaluations)",
+    "flux": """
+data = from(bucket: "default")
+    |> range(start: -duration(v: int(v: task.every) * 2))
+    |> filter(fn: (r) =>
+        (r._measurement == "feature_evaluation"))
+
+data
+    |> aggregateWindow(fn: sum, every: 15m)
+    |> filter(fn: (r) =>
+        (exists r._value))
+    |> to(bucket: "default_downsampled_15m")
+""",
+    "every": "15m",
+}, {
+    "name": "Downsample API 1h",
+    "flux": """
+data = from(bucket: "default")
+    |> range(start: -duration(v: int(v: task.every) * 2))
+    |> filter(fn: (r) =>
+        (r._measurement == "api_call"))
+
+data
+    |> aggregateWindow(fn: sum, every: 1h)
+    |> filter(fn: (r) =>
+      (exists r._value))
+    |> to(bucket: "default_downsampled_1h")
+""",
+    "every": "1h",
+}, {
+    "name": "Downsample API 1h - Flag Analytics",
+    "flux": """
+data = from(bucket: "default")
+    |> range(start: -duration(v: int(v: task.every) * 2))
+    |> filter(fn: (r) =>
+        (r._measurement == "feature_evaluation"))
+    |> filter(fn: (r) =>
+        (r._field == "request_count"))
+    |> group(columns: ["feature_id", "environment_id"])
+
+data
+    |> aggregateWindow(fn: sum, every: 1h)
+    |> filter(fn: (r) =>
+      (exists r._value))
+    |> set(key: "_measurement", value: "feature_evaluation")
+    |> set(key: "_field", value: "request_count")
+    |> to(bucket: "default_downsampled_1h")
+""",
+    "every": "1h",
+}]
+
+print("Creating tasks if needed...")
+tasks = client.tasks_api()
+for task_definition in tasks_to_ensure_exist:
+    if not tasks.find_tasks(name=task_definition["name"], org_id=organization.id):
+        print("Task {} does not exist. Creating...".format(task_definition["name"]))
+        tasks.create_task_every(task_definition["name"], task_definition["flux"], task_definition["every"], organization)
+        print("Created task {}.".format(task_definition["name"]))
+    else:
+        print("Task {} already exists. Nothing to do.".format(task_definition["name"]))
+print("Finished creating tasks if needed.")
+
+print("Finished configuring InfluxDB at {}".format(influxdb_url))

--- a/charts/flagsmith/templates/configmap-influxdb-setup.yaml
+++ b/charts/flagsmith/templates/configmap-influxdb-setup.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.api.influxdbEnsureSetup }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "flagsmith.fullname" . }}-influxdb-setup
+  labels:
+    {{- include "flagsmith.labels" . | nindent 4 }}
+    app.kubernetes.io/component: influxdb-setup
+data:
+  influxdb_setup.py: |
+{{ include (print $.Template.BasePath "/_influxdb_setup.txt") . | indent 4 }}
+{{- end }}

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -18,6 +18,9 @@ spec:
         {{- if and .Values.influxdbExternal.enabled (not .Values.influxdbExternal.tokenFromExistingSecret.enabled) }}
         checksum/secrets-influxdb-external: {{ include (print $.Template.BasePath "/secrets-influxdb-external.yaml") . | sha256sum }}
         {{- end }}
+        {{- if and .Values.influxdbEnsureSetup }}
+        checksum/configmap-influxdb-ensure-setup: {{ include (print $.Template.BasePath "/_influxdb_setup.py") . | sha256sum }}
+        {{- end }}
 {{- if .Values.api.podAnnotations }}
 {{ toYaml .Values.api.podAnnotations | nindent 8 }}
 {{- end }}
@@ -73,6 +76,18 @@ spec:
         imagePullPolicy: {{ .Values.api.image.imagePullPolicy }}
         args: ["migrate"]
         env: {{ include (print $.Template.BasePath "/_api_environment.yaml") . | nindent 8 }}
+{{- if .Values.api.influxdbEnsureSetup }}
+      - name: influxdb-setup
+        image: {{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default (printf "%s" .Chart.AppVersion) }}
+        imagePullPolicy: {{ .Values.api.image.imagePullPolicy }}
+        command:
+          - python
+          - /influxdb_setup/influxdb_setup.py
+        env: {{ include (print $.Template.BasePath "/_api_environment.yaml") . | nindent 8 }}
+        volumeMounts:
+          - name: influxdb-setup
+            mountPath: /influxdb_setup/
+{{- end }}
       containers:
       - name: {{ .Chart.Name }}-api
         image: {{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default (printf "%s" .Chart.AppVersion) }}
@@ -104,3 +119,9 @@ spec:
           timeoutSeconds: {{ .Values.api.readinessProbe.timeoutSeconds }}
         resources:
 {{ toYaml .Values.api.resources | indent 10 }}
+{{- if .Values.api.influxdbEnsureSetup }}
+      volumes:
+        - name: influxdb-setup
+          configMap:
+            name: {{ template "flagsmith.fullname" . }}-influxdb-setup
+{{- end }}

--- a/charts/flagsmith/templates/tests/test-e2e-monster.yaml
+++ b/charts/flagsmith/templates/tests/test-e2e-monster.yaml
@@ -74,6 +74,11 @@ spec:
           eval "export E2E_TEST_TOKEN_$AUTH_TOKEN_PROJECT_NAME=$E2E_TEST_TOKEN_PROD" &&
           env | grep E2E_ &&
           npm run env &&
+          cat ./common/project.js &&
+          sed -i -e 's|^\s*api:.*|api: process.env.PROXY_API_URL + "/api/v1/",|' ./common/project.js &&
+          sed -i -e 's|^\s*flagsmithClientAPI:.*|flagsmithClientAPI: process.env.PROXY_API_URL + "/api/v1/",|' ./common/project.js &&
+          sed -i -e 's|^\s*flagsmithClientEdgeAPI:.*|flagsmithClientEdgeAPI: process.env.PROXY_API_URL + "/api/v1/",|' ./common/project.js &&
+          cat ./common/project.js &&
           npm run test)) &&
           echo "Tests ran successfully"
 

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -60,6 +60,7 @@ api:
       tag: latest
       imagePullPolicy: IfNotPresent
     timeoutSeconds: 30
+  influxdbEnsureSetup: false
 
 frontend:
   # Set this to `false` to switch off the frontend (deployment,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

:construction: a work in progress

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version`

## Changes

This builds on #78 and is related to #40. In #78 I had to switch off influxdb for the e2e tests to pass. This switches it back on, and so (I expect) the tests to now fail.

The goal is to make it so influxdb is enabled, but the tests pass.

## How did you test this code?

Waited for CI and expected it to fail.