### PR TITLE
Move health path from pgbouncer to api

### DIFF
--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -36,12 +36,14 @@ api:
     # runAsUser: 1000
     # runAsGroup: 1000
   livenessProbe:
+    path: /health
     failureThreshold: 5
     initialDelaySeconds: 5
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 2
   readinessProbe:
+    path: /health
     failureThreshold: 10
     initialDelaySeconds: 1
     periodSeconds: 10
@@ -149,14 +151,12 @@ pgbouncer:
         - all
 
   livenessProbe:
-    path: /health
     failureThreshold: 5
     initialDelaySeconds: 5
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 2
   readinessProbe:
-    path: /health
     failureThreshold: 10
     initialDelaySeconds: 1
     periodSeconds: 10


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [ ] ~I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version`~

## Changes

Correctly add the health path to the api section in values.yaml instead of the pgbouncer section.

## How did you test this code?

Reliant on automated tests
