### PR TITLE
Add support for Extra volume and Volume mounts

### DIFF
--- a/charts/flagsmith/templates/_api_environment.yaml
+++ b/charts/flagsmith/templates/_api_environment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.databaseExternal.url }}
 - name: DATABASE_URL
   valueFrom:
     secretKeyRef:
@@ -8,6 +9,7 @@
       name: {{ template "flagsmith.fullname" . }}
       key: DATABASE_URL
       {{- end }}
+{{- end }}
 {{- if .Values.api.secretKey }}
 - name: DJANGO_SECRET_KEY
   valueFrom:

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -82,6 +82,8 @@ spec:
         ports:
         - containerPort: {{ .Values.service.api.port }}
         env: {{ include (print $.Template.BasePath "/_api_environment.yaml") . | nindent 8 }}
+        extraVolumeMounts:
+          {{- toYaml .Values.extraVolumeMounts | default "" | nindent 12 }} 
         livenessProbe:
           failureThreshold: {{ .Values.api.livenessProbe.failureThreshold }}
           httpGet:
@@ -104,3 +106,6 @@ spec:
           timeoutSeconds: {{ .Values.api.readinessProbe.timeoutSeconds }}
         resources:
 {{ toYaml .Values.api.resources | indent 10 }}
+      extraVolumes:
+        {{- toYaml .Values.extraVolumes | default "" | nindent 8 }}     
+

--- a/charts/flagsmith/templates/secrets-api.yaml
+++ b/charts/flagsmith/templates/secrets-api.yaml
@@ -7,7 +7,9 @@ metadata:
     app.kubernetes.io/component: api
 type: Opaque
 data:
+{{- if .Values.databaseExternal.url }}
   DATABASE_URL: {{ include "flagsmith.api.databaseUrl" . | trim | b64enc | quote }}
+{{- end }}
 {{- with .Values.api.secretKey }}
   DJANGO_SECRET_KEY: {{ . | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a release branch

## Changes

To fetch external database credentials stored as secrets in the Azure key vault, It's required to mount secrets to the container filesystem.
If DATABASE_URL is not used, Env vars should be used for DB connection

## How did you test this code?

Tested deployment in own environment

