### PR TITLE
Statsd

### DIFF
--- a/charts/flagsmith/Chart.lock
+++ b/charts/flagsmith/Chart.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: influxdb2
   repository: https://helm.influxdata.com/
   version: 2.0.0
-digest: sha256:92b012870c0ab1caf6fb70662d8d59469552bf40c940de57924c598a951dea6e
-generated: "2021-09-20T16:53:03.089573+02:00"
+- name: graphite
+  repository: https://kiwigrid.github.io
+  version: 0.7.3
+digest: sha256:08185ea3318322a875104ec4b2daca39b264587868ea3ebc5053c1bf6dd7576f
+generated: "2022-10-25T21:11:00.806235474+01:00"

--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.10.2
-appVersion: 2.26.0
+version: 0.11.0
+appVersion: 2.34.0
 dependencies:
   - name: postgresql
     repository: https://charts.helm.sh/stable
@@ -14,6 +14,10 @@ dependencies:
     # pinned due to issue https://github.com/influxdata/helm-charts/issues/350
     version: 2.0.0
     condition: influxdb2.enabled
+  - name: graphite
+    repository: https://kiwigrid.github.io
+    version: 0.7.3
+    condition: graphite.enabled
 icon: https://docs.flagsmith.com/img/square-icon.png
 # maintainers:
 #   - name: Ben Rometsch, Matt Elwell

--- a/charts/flagsmith/templates/_api_environment.yaml
+++ b/charts/flagsmith/templates/_api_environment.yaml
@@ -51,6 +51,28 @@
 - name: {{ $envName }}
   value: {{ $envValue | quote }}
 {{- end }}
+{{- with .Values.api.statsd }}
+{{- if .enabled }}
+- name: STATSD_HOST
+{{- if .host }}
+  value: {{ .host }}
+{{- else if .hostFromNodeIp }}
+  valueFrom:
+    fieldRef:
+      fieldPath: status.hostIP
+{{- else if (and $.Values.graphite.enabled $.Values.graphite.autoSetStatsdHostEnvVar) }}
+  value: {{ template "flagsmith.graphite.fullname" $ }}
+{{- else }}
+{{ fail "Must set api.statsd.host or api.statsd.hostFromNodeIp or enable graphite and set graphite.autoSetStatsdHostEnvVar" }}
+{{- end }}
+- name: STATSD_PORT
+  value: {{ .port | quote }}
+{{- if .prefix }}
+- name: STATSD_PREFIX
+  value: {{ .prefix }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- range $envName, $secretKeyRef := .Values.api.extraEnvFromSecret }}
 - name: {{ $envName }}
   valueFrom:

--- a/charts/flagsmith/templates/_helpers.tpl
+++ b/charts/flagsmith/templates/_helpers.tpl
@@ -203,6 +203,23 @@ Influxdb hostname
 {{- end -}}
 
 {{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "flagsmith.graphite.fullname" -}}
+{{- if .Values.graphite.fullnameOverride -}}
+{{- .Values.graphite.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.graphite.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name "flagsmith-graphite" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Frontend environment
 */}}
 {{- define "flagsmith.frontend.environment" -}}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -60,6 +60,12 @@ api:
       tag: latest
       imagePullPolicy: IfNotPresent
     timeoutSeconds: 30
+  statsd:
+    enabled: false
+    host: null
+    hostFromNodeIp: false
+    port: 8125
+    prefix: flagsmith.api
 
 frontend:
   # Set this to `false` to switch off the frontend (deployment,
@@ -200,6 +206,12 @@ influxdbExternal:
     enabled: false
     name: null
     key: null
+
+# This is included primarily for easy testing of statsd integration from the application.
+graphite:
+  enabled: false
+  nameOverride: flagsmith-graphite
+  autoSetStatsdHostEnvVar: true
 
 service:
   api:

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,6 +1,7 @@
 chart-repos:
   - stable=https://charts.helm.sh/stable
   - influxdata=https://helm.influxdata.com/
+  - kiwigrid=https://kiwigrid.github.io
 target-branch: main
 validate-maintainers: false
 helm-extra-args: '--timeout 30m'


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a release branch

## Changes

Adds support to the chart for integrating with statsd. See https://github.com/Flagsmith/flagsmith/pull/1552

## How did you test this code?

Deployed to minikube with the following options:
```yaml
api:
  statsd:
    enabled: true

graphite:
  enabled: true
  autoSetStatsdHostEnvVar: true
```
Then:
- port-forwarded to access the frontend, hit refresh a few times
- then port-forwarded to graphite, and saw that some metrics had arrived, eg at: Metrics > stats > flagsmith > api > gunicorn > request > status > 200, and that graphing this showed that the site had served me some 200 responses.

---

Then, separately have also verified that setting the statsd host as you would for use with Datadog (that is, setting `api.statsd.hostFromNodeIp: true` sets the `STATSD_HOST` env var as expected. Eg:
```
$ kubectl -n flagsmith exec -it deployment/flagsmith-test-api -c flagsmith-api -- env | grep STATSD_HOST
STATSD_HOST=192.168.49.2
```
which is the IP of the only node in my minikube:
```
$ kubectl get nodes -o 'jsonpath={.items[].status.addresses[0].address}'
192.168.49.2
```
However, I have not tested this with Datadog, but the above leads me to believe the chart is setting everything correctly.

---

Note that as this adds a feature, I have bumped the chart minor version. Also, this feature relies on a new feature in the application, so I have bumped the application version number too. I reason this is valid as the application is a minor version bump too.

---

Follow-up task, if this looks good, is to document these options and what they do.