### PR TITLE
Fix release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,9 +25,12 @@ jobs:
           version: v3.5.4
 
       - name: Add chart repo dependencies
+        # Note: this repos should match whith the repos set in ct.yaml
+        # See https://github.com/Flagsmith/flagsmith-charts/issues/105
         run: |
           helm repo add stable https://charts.helm.sh/stable
           helm repo add influxdb2 https://helm.influxdata.com/
+          helm repo add kiwigrid https://kiwigrid.github.io
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.0

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,3 +1,5 @@
+# Note: any repos listed here must also be added in the release github action
+# See https://github.com/Flagsmith/flagsmith-charts/issues/105
 chart-repos:
   - stable=https://charts.helm.sh/stable
   - influxdata=https://helm.influxdata.com/


### PR DESCRIPTION
Have made #105 to find a way of doing this better, maybe.

For now, just setting the repo in the place where it is currently missing is probably best, as it means the merged chart can be released.