### PR TITLE
Do not set replicas if set to null

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.11.1
+version: 0.11.2
 appVersion: 2.34.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/_helpers.tpl
+++ b/charts/flagsmith/templates/_helpers.tpl
@@ -308,3 +308,12 @@ args:
   - 'URL: %{url_effective}\nHTTP status code: %{http_code}\nBytes downloaded: %{size_download}\nTime taken: %{time_total}s\n'
   - {{ .url | squote }}
 {{- end }}
+
+{{/*
+Replicas
+*/}}
+{{- define "flagsmith.replicaCount" -}}
+{{- if not (kindIs "invalid" .) -}}
+replicas: {{ . }}
+{{- end }}
+{{- end }}

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -10,7 +10,7 @@ spec:
     matchLabels:
       {{- include "flagsmith.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: api
-  replicas: {{ .Values.api.replicacount }}
+  {{- include "flagsmith.replicaCount" .Values.api.replicacount | nindent 2 }}
   template:
     metadata:
       annotations:

--- a/charts/flagsmith/templates/deployment-frontend.yaml
+++ b/charts/flagsmith/templates/deployment-frontend.yaml
@@ -11,7 +11,7 @@ spec:
     matchLabels:
       {{- include "flagsmith.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: frontend
-  replicas: {{ .Values.frontend.replicacount }}
+  {{- include "flagsmith.replicaCount" .Values.frontend.replicacount | nindent 2 }}
   template:
     metadata:
       {{- if .Values.frontend.podAnnotations }}

--- a/charts/flagsmith/templates/deployment-pgbouncer.yaml
+++ b/charts/flagsmith/templates/deployment-pgbouncer.yaml
@@ -11,7 +11,7 @@ spec:
     matchLabels:
       {{- include "flagsmith.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: pgbouncer
-  replicas: {{ .Values.pgbouncer.replicacount }}
+  {{- include "flagsmith.replicaCount" .Values.pgbouncer.replicacount | nindent 2 }}
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Fixes #113.

Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a release branch

## Changes

If `replicacount` is null, don't set replicas on a deployment.

## How did you test this code?

Deployed to minikube with `replicacount` set to `null` and then 0 and saw that the right thing happened.