### PR TITLE
Allow setting strategy on deployments

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.11.1
+version: 0.12.0
 appVersion: 2.34.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -11,6 +11,9 @@ spec:
       {{- include "flagsmith.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: api
   replicas: {{ .Values.api.replicacount }}
+  {{- with .Values.api.deploymentStrategy }}
+  strategy: {{- . | toYaml | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/flagsmith/templates/deployment-frontend.yaml
+++ b/charts/flagsmith/templates/deployment-frontend.yaml
@@ -12,6 +12,9 @@ spec:
       {{- include "flagsmith.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: frontend
   replicas: {{ .Values.frontend.replicacount }}
+  {{- with .Values.frontend.deploymentStrategy }}
+  strategy: {{- . | toYaml | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       {{- if .Values.frontend.podAnnotations }}

--- a/charts/flagsmith/templates/deployment-pgbouncer.yaml
+++ b/charts/flagsmith/templates/deployment-pgbouncer.yaml
@@ -12,6 +12,9 @@ spec:
       {{- include "flagsmith.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: pgbouncer
   replicas: {{ .Values.pgbouncer.replicacount }}
+  {{- with .Values.pgbouncer.deploymentStrategy }}
+  strategy: {{- . | toYaml | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -14,6 +14,7 @@ api:
   # deployment's pods.
   separateApiAndFrontend: true
   replicacount: 1
+  deploymentStrategy: null
   podAnnotations: {}
   resources: {}
   # limits:
@@ -79,6 +80,7 @@ frontend:
     imagePullPolicy: IfNotPresent
     imagePullSecrets: []
   replicacount: 1
+  deploymentStrategy: null
   resources: {}
   # limits:
   #   cpu: 500m
@@ -143,6 +145,7 @@ pgbouncer:
     imagePullPolicy: IfNotPresent
     imagePullSecrets: []
   replicaCount: 1
+  deploymentStrategy: null
   podAnnotations: {}
   resources: {}
   podLabels: {}


### PR DESCRIPTION
Fixes #114.

Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a release branch

## Changes

Allow setting the strategy on the deployments. See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy

I have decided that this is a "change" but #115 is a "fix", mostly so the chart version numbers are a bit less faffy for me, but only if this PR is merged after #115. Happy to adjust.

## How did you test this code?

Deployed to minikube, tested that setting values for this do indeed get set on the deployments.
