### PR TITLE
Generate secret key if not set

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.12.0
+version: 0.13.0
 appVersion: 2.34.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/NOTES.txt
+++ b/charts/flagsmith/templates/NOTES.txt
@@ -30,9 +30,10 @@ for information about how to gain web access to the application.
 ##### Warning: no secret key set #####
 ######################################
 
-No secret key is set. For production systems, it is strongly
-recommended to generate a large random value and set it at
-`api.secretKey`. It must be kept secret.
+No secret key is set, a new one will be randomly generated at each
+deployment. For production systems, it is strongly recommended to
+generate a large random value and set it at `api.secretKey`. It must
+be kept secret.
 
 See https://docs.flagsmith.com/deployment/locally-api#creating-a-secret-key
 {{- end }}

--- a/charts/flagsmith/templates/_api_environment.yaml
+++ b/charts/flagsmith/templates/_api_environment.yaml
@@ -8,13 +8,11 @@
       name: {{ template "flagsmith.fullname" . }}
       key: DATABASE_URL
       {{- end }}
-{{- if .Values.api.secretKey }}
 - name: DJANGO_SECRET_KEY
   valueFrom:
     secretKeyRef:
       name: {{ template "flagsmith.fullname" . }}
       key: DJANGO_SECRET_KEY
-{{- end }}
 {{- if .Values.influxdb2.enabled }}
 - name: INFLUXDB_URL
   value: http://{{- template "flagsmith.influxdb.hostname" . -}}:80

--- a/charts/flagsmith/templates/secrets-api.yaml
+++ b/charts/flagsmith/templates/secrets-api.yaml
@@ -8,6 +8,4 @@ metadata:
 type: Opaque
 data:
   DATABASE_URL: {{ include "flagsmith.api.databaseUrl" . | trim | b64enc | quote }}
-{{- with .Values.api.secretKey }}
-  DJANGO_SECRET_KEY: {{ . | b64enc | quote }}
-{{- end }}
+  DJANGO_SECRET_KEY: {{ .Values.api.secretKey | default (randAlphaNum 50) | b64enc | quote }}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a release branch

## Changes

By default, set a randomly generated value for the secret key. This changes the existing behaviour, where no value is set, so each container in each API pod will generate itself a secret key at startup, so with multiple replicas, each will end up with a different secret key, which will confuse some things. A consistent value across all running pods is better.

In practice, deployments ought to have set `api.secretKey`, per the message generated from `NOTES.txt`.

So while this is not ideal (helm makes it fiddly to do better), I believe it is a strict improvement. And the "right answer" remains "set `api.secretKey`".

## How did you test this code?

Deployment to minikube, saw that a value was generated, but I still got a warning:
```
######################################
##### Warning: no secret key set #####
######################################

No secret key is set, a new one will be randomly generated at each
deployment. For production systems, it is strongly recommended to
generate a large random value and set it at `api.secretKey`. It must
be kept secret.

See https://docs.flagsmith.com/deployment/locally-api#creating-a-secret-key
```

But if I do set a value, the value stays as what I set it to on each deployment.