### PR TITLE
Issue 120: update influxdb chart

### DIFF
--- a/charts/flagsmith/Chart.lock
+++ b/charts/flagsmith/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 8.6.4
 - name: influxdb2
   repository: https://helm.influxdata.com/
-  version: 2.0.0
+  version: 2.1.1
 - name: graphite
   repository: https://kiwigrid.github.io
   version: 0.7.3
-digest: sha256:08185ea3318322a875104ec4b2daca39b264587868ea3ebc5053c1bf6dd7576f
-generated: "2022-10-25T21:11:00.806235474+01:00"
+digest: sha256:1da2ab7c98cb0226469fd785d5d98431148486c6cecde9e419c73c2c0dc325b8
+generated: "2023-01-05T15:28:01.898891176Z"

--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.15.0
+version: 0.16.0
 appVersion: 2.34.0
 dependencies:
   - name: postgresql
@@ -11,8 +11,7 @@ dependencies:
     condition: postgresql.enabled
   - name: influxdb2
     repository: https://helm.influxdata.com/
-    # pinned due to issue https://github.com/influxdata/helm-charts/issues/350
-    version: 2.0.0
+    version: 2.1.1
     condition: influxdb2.enabled
   - name: graphite
     repository: https://kiwigrid.github.io


### PR DESCRIPTION
Fixes #120.

Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a release branch

## Changes

Upgrade influxdb

## How did you test this code?

Deployed to minikube running k8s 1.22, with values:
```yaml
api:
  influxdbSetup:
    enabled: true
influxdb2:
  enabled: true
```
Saw that influxdb became healthy, and that the setup steps worked as expected:
```
$ kubectl -n flagsmith logs deployment/flagsmith-test-api -c influxdb-setup
Configuring InfluxDB at http://flagsmith-test-influxdb2.flagsmith.svc.cluster.local:80
Checking for ping...
Successfully pinged influxdb
Creating buckets if needed...
Bucket default already exists. Nothing to do.
Bucket default_downsampled_15m does not exist. Creating...
Created bucket default_downsampled_15m.
Bucket default_downsampled_1h does not exist. Creating...
Created bucket default_downsampled_1h.
Finished creating buckets if needed.
Creating tasks if needed...
Task Downsample (API Requests) does not exist. Creating...
Created task Downsample (API Requests).
Task Downsample (Flag Evaluations) does not exist. Creating...
Created task Downsample (Flag Evaluations).
Task Downsample API 1h does not exist. Creating...
Created task Downsample API 1h.
Task Downsample API 1h - Flag Analytics does not exist. Creating...
Created task Downsample API 1h - Flag Analytics.
Finished creating tasks if needed.
Finished configuring InfluxDB at http://flagsmith-test-influxdb2.flagsmith.svc.cluster.local:80
```