### PR TITLE
Issue 121: update Postgres chart and identify as "dev"

### DIFF
--- a/charts/flagsmith/Chart.lock
+++ b/charts/flagsmith/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
-  repository: https://charts.helm.sh/stable
-  version: 8.6.4
+  repository: https://charts.bitnami.com/bitnami
+  version: 12.5.8
 - name: influxdb2
   repository: https://helm.influxdata.com/
   version: 2.1.1
 - name: graphite
   repository: https://kiwigrid.github.io
   version: 0.7.3
-digest: sha256:1da2ab7c98cb0226469fd785d5d98431148486c6cecde9e419c73c2c0dc325b8
-generated: "2023-04-18T16:20:35.478691+01:00"
+digest: sha256:6ed1b4fab608bb1039a42040c445cfdf6a74a32ac80d4b1137f420e86f08e481
+generated: "2023-06-20T13:58:28.286957382+01:00"

--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,13 +2,16 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.22.0
+version: 0.23.0
 appVersion: 2.57.0
 dependencies:
   - name: postgresql
-    repository: https://charts.helm.sh/stable
-    version: 8.6.4
-    condition: postgresql.enabled
+    repository: https://charts.bitnami.com/bitnami
+    version: 12.5.8
+    # Handle the previous flag too, see
+    # https://v2.helm.sh/docs/developing_charts/#tags-and-condition-fields-in-requirements-yaml
+    condition: postgresql.enabled,devPostgresql.enabled
+    alias: devPostgresql
   - name: influxdb2
     repository: https://helm.influxdata.com/
     version: 2.1.1

--- a/charts/flagsmith/README.md
+++ b/charts/flagsmith/README.md
@@ -2,3 +2,7 @@
 
 For documentation on this Helm chart, please refer to the
 [Flagsmith Docs](https://docs.flagsmith.com/deployment/kubernetes).
+
+In particular, [key upgrade
+notes](https://docs.flagsmith.com/deployment/hosting/kubernetes#key-upgrade-notes)
+for information on upgrading chart versions.

--- a/charts/flagsmith/templates/_helpers.tpl
+++ b/charts/flagsmith/templates/_helpers.tpl
@@ -56,10 +56,10 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "flagsmith.postgresql.fullname" -}}
-{{- if .Values.postgresql.fullnameOverride -}}
-{{- .Values.postgresql.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.devPostgresql.fullnameOverride -}}
+{{- .Values.devPostgresql.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- $name := default .Chart.Name .Values.postgresql.nameOverride -}}
+{{- $name := default .Chart.Name .Values.devPostgresql.nameOverride -}}
 {{- if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -72,10 +72,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Set postgres host
 */}}
 {{- define "flagsmith.postgresql.host" -}}
-{{- if .Values.postgresql.enabled -}}
+{{- if .Values.devPostgresql.enabled -}}
 {{- template "flagsmith.postgresql.fullname" . -}}
 {{- else -}}
-{{- .Values.postgresql.postgresqlHost | quote -}}
+{{- .Values.devPostgresql.postgresqlHost | quote -}}
 {{- end -}}
 {{- end -}}
 
@@ -83,7 +83,7 @@ Set postgres host
 Set postgres secret
 */}}
 {{- define "flagsmith.postgresql.secret" -}}
-{{- if .Values.postgresql.enabled -}}
+{{- if .Values.devPostgresql.enabled -}}
 {{- template "flagsmith.postgresql.fullname" . -}}
 {{- else -}}
 {{- template "flagsmith.fullname" . -}}
@@ -94,10 +94,10 @@ Set postgres secret
 Set postgres secretKey
 */}}
 {{- define "flagsmith.postgresql.secretKey" -}}
-{{- if .Values.postgresql.enabled -}}
+{{- if .Values.devPostgresql.enabled -}}
 "postgresql-password"
 {{- else -}}
-{{- default "postgresql-password" .Values.postgresql.existingSecretKey | quote -}}
+{{- default "postgresql-password" .Values.devPostgresql.existingSecretKey | quote -}}
 {{- end -}}
 {{- end -}}
 
@@ -105,10 +105,10 @@ Set postgres secretKey
 Set postgres port
 */}}
 {{- define "flagsmith.postgresql.port" -}}
-{{- if .Values.postgresql.enabled -}}
+{{- if .Values.devPostgresql.enabled -}}
     "5432"
 {{- else -}}
-{{- default "5432" .Values.postgresql.postgresqlPort | quote -}}
+{{- default "5432" .Values.devPostgresql.postgresqlPort | quote -}}
 {{- end -}}
 {{- end -}}
 
@@ -160,7 +160,7 @@ Set redis port
 Postgres hostname
 */}}
 {{- define "flagsmith.postgres.hostname" -}}
-{{- printf "%s-%s" .Release.Name .Values.postgresql.nameOverride -}}.{{ .Release.Namespace }}.svc.cluster.local
+{{- printf "%s-%s" .Release.Name .Values.devPostgresql.nameOverride -}}.{{ .Release.Namespace }}.svc.cluster.local
 {{- end -}}
 
 {{/*
@@ -268,8 +268,8 @@ Database URL
 {{- end -}}
 {{- end -}}
 {{- end -}}
-{{- else if .Values.postgresql.enabled -}}
-{{- printf "%s://%s:%s@%s:%s/%s" "postgres" (required "Must specify a postgres username" .Values.postgresql.postgresqlUsername) (required "Must specify a postgres password" .Values.postgresql.postgresqlPassword) (include "flagsmith.postgres.hostname" . ) "5432" (required "Must specify a postgres database name" .Values.postgresql.postgresqlDatabase) -}}
+{{- else if .Values.devPostgresql.enabled -}}
+{{- printf "%s://%s:%s@%s:%s/%s" "postgres" (.Values.devPostgresql.auth.username | default "postgres") (.Values.devPostgresql.auth.password | default .Values.devPostgresql.auth.postgresPassword | required "Must specify a postgres password") (include "flagsmith.postgres.hostname" . ) "5432" (required "Must specify a postgres database name" .Values.devPostgresql.auth.database) -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -171,14 +171,14 @@ taskProcessor:
     # runAsUser: 1000
     # runAsGroup: 1000
 
-postgresql:
+devPostgresql:
   enabled: true
   serviceAccount:
-    enabled: true
-  nameOverride: flagsmith-postgresql
-  postgresqlDatabase: flagsmith
-  postgresqlUsername: postgres
-  postgresqlPassword: flagsmith
+    create: true
+  nameOverride: dev-postgresql
+  auth:
+    postgresPassword: flagsmith
+    database: flagsmith
 
 databaseExternal:
   enabled: false

--- a/ct.yaml
+++ b/ct.yaml
@@ -2,6 +2,7 @@
 # See https://github.com/Flagsmith/flagsmith-charts/issues/105
 chart-repos:
   - stable=https://charts.helm.sh/stable
+  - bitnami=https://charts.bitnami.com/bitnami
   - influxdata=https://helm.influxdata.com/
   - kiwigrid=https://kiwigrid.github.io
 target-branch: main


### PR DESCRIPTION
Fixes #121.

Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a release branch

## Changes

Update the bundled Postgres chart from chart version 8 in the old "stable" repos to chart version 12 in bitnami's repo.

**No effort has been made to preserve data. All of the k8s resources will get replaced. Per the warning at https://docs.flagsmith.com/deployment/kubernetes#provided-database-configuration, recommend storing data in an external database**

I reviewed the documentation at https://docs.bitnami.com/kubernetes/infrastructure/postgresql/administration/upgrade/ and determined that it would be silly to try to preserve data.

Further, have renamed to `dev-postgres` to make it very clear what this is for. There will be some documentation to update to accommodate this, but helm does handle our main use case: we want for users who have already set `postgresql.enabled=false` to still not have an in-cluster postgres after deploying this change, even though the name of the setting is now `devPostgresql.enabled`. Helm handles this for us, see https://v2.helm.sh/docs/developing_charts/#tags-and-condition-fields-in-requirements-yaml. So if `postgresql.enabled` is set to something, use that value. Otherwise use `devPostgresql.enabled`.

Below is the behaviour users will see based on the values they have set in their values:

| `postgresql.enabled` | `devPostgresql.enabled` | PG before? | PG after? | Notes |
| --- | --- | --- | --- | --- |
| [unset] | [unset] | yes | yes | :heavy_check_mark: 
| true | [unset] | yes | yes | :heavy_check_mark: |
| false | [unset] | no | no | :heavy_check_mark: (this is the important one)|
| [unset] | true | yes | yes | :heavy_check_mark: |
| true | true | yes | yes | :heavy_check_mark: |
| false | true | no | no | possibly slightly confusing, but inevitable as the values are asking for contradictory things |
| [unset] | false | yes | no | is a change in behaviour, but only a problem if a user has already set `devPostgresql.enabled=false` prior to upgrading for some reason, but not set `postgresql.enabled=false` and does want in-cluster Postgres. So this is actually what we want. |
| true | false | yes | yes | possibly slightly confusing, but inevitable as the values are asking for contradictory things |
| false | false | no | no | :heavy_check_mark: |

(PG before: "use the value in the first column if set, otherwise be yes"; PG after: "use the value in the first column if set, otherwise use the value in the second column, otherwise be yes")

So I think this behaves correctly, and the only possible surprises are where `postgresql.enabled` and `devPostgresql.enabled` are explicitly contradictory.

## How did you test this code?

Deployed to minikube and check the upgrade was clean. Checked that `postgresql.enabled`/`devPostgresql.enabled` behaved as expected.
