### PR TITLE
Issue 127: fix bad apiProxy.enabled check

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.16.1
+version: 0.16.2
 appVersion: 2.42.1
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/_helpers.tpl
+++ b/charts/flagsmith/templates/_helpers.tpl
@@ -225,7 +225,7 @@ Frontend environment
 {{- define "flagsmith.frontend.environment" -}}
 - name: ASSET_URL
   value: '/'
-{{- if and .Values.frontend.apiProxy.enabled false }}
+{{- if .Values.frontend.apiProxy.enabled }}
 - name: PROXY_API_URL
   value: http://{{ include "flagsmith.fullname" . }}-api.{{ .Release.Namespace }}:{{ .Values.service.api.port }}
 - name: FLAGSMITH_PROXY_API_URL


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes

Fixes #127.

## How did you test this code?

Deployed unfixed chart with default values, saw that when trying to login, the frontend made a request to `https://api-staging.flagsmith.com/api/v1/auth/login/`, as reported in the issue.

Deployed chart with this fix, saw that when trying to login, the fronted made a request to `http://localhost:8080/api/v1/auth/login/` instead.
