### PR TITLE
Separate task processor image from API

### DIFF
--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -44,7 +44,7 @@ spec:
       {{- if .Values.taskProcessor.schedulerName }}
       schedulerName: "{{ .Values.taskProcessor.schedulerName }}"
       {{- end }}
-      {{- if (.Values.taskProcessor.image).imagePullSecrets }}
+      {{- if .Values.taskProcessor.image.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.taskProcessor.image.imagePullSecrets | indent 8 }}
       {{- else if .Values.api.image.imagePullSecrets }}
@@ -59,8 +59,8 @@ spec:
         {{- toYaml $securityContext | nindent 8 }}
       containers:
       - name: {{ .Chart.Name }}-task-processor
-        image: {{ (.Values.taskProcessor.image).repository | default .Values.api.image.repository }}:{{ (.Values.taskProcessor.image).tag | default .Values.api.image.tag | default .Chart.AppVersion }}
-        imagePullPolicy: {{ (.Values.taskProcessor.image).imagePullPolicy | default .Values.api.image.imagePullPolicy }}
+        image: {{ .Values.taskProcessor.image.repository | default .Values.api.image.repository }}:{{ .Values.taskProcessor.image.tag | default .Values.api.image.tag | default .Chart.AppVersion }}
+        imagePullPolicy: {{ .Values.taskProcessor.image.imagePullPolicy | default .Values.api.image.imagePullPolicy }}
         command:
           - python
           - manage.py

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -44,14 +44,12 @@ spec:
       {{- if .Values.taskProcessor.schedulerName }}
       schedulerName: "{{ .Values.taskProcessor.schedulerName }}"
       {{- end }}
-      {{- if or .Values.taskProcessor.image.imagePullSecrets .Values.api.image.imagePullSecrets }}
+      {{- if (.Values.taskProcessor.image).imagePullSecrets }}
       imagePullSecrets:
-      {{- if .Values.taskProcessor.image.imagePullSecrets }}
 {{ toYaml .Values.taskProcessor.image.imagePullSecrets | indent 8 }}
-      {{- end }}
-      {{- if .Values.api.image.imagePullSecrets }}
+      {{- else if .Values.api.image.imagePullSecrets }}
+      imagePullSecrets:
 {{ toYaml .Values.api.image.imagePullSecrets | indent 8 }}
-      {{- end }}
       {{- end }}
       securityContext:
         {{- $securityContext := .Values.taskProcessor.podSecurityContext | default (dict) | deepCopy }}
@@ -61,8 +59,8 @@ spec:
         {{- toYaml $securityContext | nindent 8 }}
       containers:
       - name: {{ .Chart.Name }}-task-processor
-        image: {{ .Values.taskProcessor.image.repository | default .Values.api.image.tag }}:{{ .Values.taskProcessor.image.tag | default .Values.api.image.tag }}
-        imagePullPolicy: {{ .Values.taskProcessor.image.imagePullPolicy | default .Values.api.image.imagePullPolicy }}
+        image: {{ (.Values.taskProcessor.image).repository | default .Values.api.image.repository }}:{{ (.Values.taskProcessor.image).tag | default .Values.api.image.tag | default .Chart.AppVersion }}
+        imagePullPolicy: {{ (.Values.taskProcessor.image).imagePullPolicy | default .Values.api.image.imagePullPolicy }}
         command:
           - python
           - manage.py

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -56,7 +56,7 @@ spec:
         {{- toYaml $securityContext | nindent 8 }}
       containers:
       - name: {{ .Chart.Name }}-task-processor
-        image: {{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default (printf "%s" .Chart.AppVersion) }}
+        image: {{ .Values.taskProcessor.image.repository }}:{{ .Values.taskProcessor.image.tag | default (printf "%s" .Chart.AppVersion) }}
         imagePullPolicy: {{ .Values.api.image.imagePullPolicy }}
         command:
           - python

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -56,7 +56,7 @@ spec:
         {{- toYaml $securityContext | nindent 8 }}
       containers:
       - name: {{ .Chart.Name }}-task-processor
-        image: {{ .Values.taskProcessor.image.repository }}:{{ .Values.taskProcessor.image.tag | default (printf "%s" .Chart.AppVersion) }}
+        image: {{ .Values.taskProcessor.image.repository }}:{{ .Values.taskProcessor.image.tag | default .Values.api.image.tag }}
         imagePullPolicy: {{ .Values.api.image.imagePullPolicy }}
         command:
           - python

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -44,9 +44,14 @@ spec:
       {{- if .Values.taskProcessor.schedulerName }}
       schedulerName: "{{ .Values.taskProcessor.schedulerName }}"
       {{- end }}
-      {{- if .Values.api.image.imagePullSecrets }}
+      {{- if or .Values.taskProcessor.image.imagePullSecrets .Values.api.image.imagePullSecrets }}
       imagePullSecrets:
+      {{- if .Values.taskProcessor.image.imagePullSecrets }}
+{{ toYaml .Values.taskProcessor.image.imagePullSecrets | indent 8 }}
+      {{- end }}
+      {{- if .Values.api.image.imagePullSecrets }}
 {{ toYaml .Values.api.image.imagePullSecrets | indent 8 }}
+      {{- end }}
       {{- end }}
       securityContext:
         {{- $securityContext := .Values.taskProcessor.podSecurityContext | default (dict) | deepCopy }}
@@ -56,8 +61,8 @@ spec:
         {{- toYaml $securityContext | nindent 8 }}
       containers:
       - name: {{ .Chart.Name }}-task-processor
-        image: {{ .Values.taskProcessor.image.repository }}:{{ .Values.taskProcessor.image.tag | default .Values.api.image.tag }}
-        imagePullPolicy: {{ .Values.api.image.imagePullPolicy }}
+        image: {{ .Values.taskProcessor.image.repository | default .Values.api.image.tag }}:{{ .Values.taskProcessor.image.tag | default .Values.api.image.tag }}
+        imagePullPolicy: {{ .Values.taskProcessor.image.imagePullPolicy | default .Values.api.image.imagePullPolicy }}
         command:
           - python
           - manage.py

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -118,6 +118,12 @@ frontend:
 
 # See https://docs.flagsmith.com/deployment/task-processor
 taskProcessor:
+  image:
+    repository: flagsmith/flagsmith-api
+    tag: null # defaults to .Chart.AppVersion
+    imagePullPolicy: IfNotPresent
+    imagePullSecrets: []
+
   enabled: false
   replicacount: 1
   sleepIntervalMs: null

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -119,8 +119,11 @@ frontend:
 # See https://docs.flagsmith.com/deployment/task-processor
 taskProcessor:
   image:
+    # all values here default to those in .Values.api.image if not configured
+    # this is to simplify the logic for those using flagsmith-api image
+    # and to maintain backwards compatibility.
     repository: flagsmith/flagsmith-api
-    tag: null # defaults to .api.image.tag for backwards compatibility
+    tag: null
     imagePullPolicy: IfNotPresent
     imagePullSecrets: []
 

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -120,7 +120,7 @@ frontend:
 taskProcessor:
   image:
     repository: flagsmith/flagsmith-api
-    tag: null # defaults to .Chart.AppVersion
+    tag: null # defaults to .api.image.tag for backwards compatibility
     imagePullPolicy: IfNotPresent
     imagePullSecrets: []
 

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -122,10 +122,10 @@ taskProcessor:
     # all values here default to those in .Values.api.image if not configured
     # this is to simplify the logic for those using flagsmith-api image
     # and to maintain backwards compatibility.
-    repository: flagsmith/flagsmith-api
+    repository: null
     tag: null
-    imagePullPolicy: IfNotPresent
-    imagePullSecrets: []
+    imagePullPolicy: null
+    imagePullSecrets: null
 
   enabled: false
   replicacount: 1


### PR DESCRIPTION
## Changes

Separates the task processor image configuration from the API image configuration.

## How did you test this code?

 - Verified all combinations of default values using `helm template` command. 
 - Verified that running the task processor and API containers using different images works correctly
