### PR TITLE
Django secret key existing secret

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.18.0
+version: 0.18.1
 appVersion: 2.42.1
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/_api_environment.yaml
+++ b/charts/flagsmith/templates/_api_environment.yaml
@@ -11,8 +11,13 @@
 - name: DJANGO_SECRET_KEY
   valueFrom:
     secretKeyRef:
+      {{- if .Values.api.secretKeyFromExistingSecret.enabled }}
+      name: {{ .Values.api.secretKeyFromExistingSecret.name }}
+      key: {{ .Values.api.secretKeyFromExistingSecret.key }}
+      {{- else }}
       name: {{ template "flagsmith.fullname" . }}
       key: DJANGO_SECRET_KEY
+      {{- end }}
 {{- if .Values.influxdb2.enabled }}
 - name: INFLUXDB_URL
   value: http://{{- template "flagsmith.influxdb.hostname" . -}}:80

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -32,6 +32,10 @@ api:
   extraEnvFromSecret: {}
   # See https://docs.flagsmith.com/deployment/locally-api#creating-a-secret-key
   secretKey: null
+  secretKeyFromExistingSecret:
+    enabled: false
+    name: null
+    key: null
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes

Allows setting the `DJANGO_SECRET_KEY` environment variable from an existing kubernetes secret.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

After my changes I ran:
`helm template flagsmith-test .` from the `charts/flagsmith` directory and verified that the default behavior still persisted

Then I ran:
`helm template flagsmith-test . --set api.secretKeyFromExistingSecret.enabled=true,api.secretKeyFromExistingSecret.name=asdf,api.secretKeyFromExistingSecret.key=YEP` and verified that the secret used the provided name and key.
