### PR TITLE
Issue 111: option to remove use of waitforit image

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.21.0
+version: 0.22.0
 appVersion: 2.57.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -62,6 +62,7 @@ spec:
       initContainers:
 {{- if eq .Values.databaseExternal.enabled false }}
       - name: wait-for-db
+{{- if .Values.api.dbWaiter.useExternalImage }}
         image: {{ .Values.api.dbWaiter.image.repository }}:{{ .Values.api.dbWaiter.image.tag }}
         imagePullPolicy: {{ .Values.api.dbWaiter.image.imagePullPolicy }}
         command:
@@ -73,6 +74,17 @@ spec:
           {{- end }}
           - --port=5432
           - --timeout={{ .Values.api.dbWaiter.timeoutSeconds }}
+{{- else }}
+        image: {{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default (printf "%s" .Chart.AppVersion) }}
+        imagePullPolicy: {{ .Values.api.image.imagePullPolicy }}
+        command:
+          - python
+          - manage.py
+          - waitfordb
+          - --waitfor
+          - {{ .Values.api.dbWaiter.timeoutSeconds | quote }}
+        env: {{ include (print $.Template.BasePath "/_api_environment.yaml") . | nindent 8 }}
+{{- end }}
 {{- end }}
       - name: migrate-db
         image: {{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default (printf "%s" .Chart.AppVersion) }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -60,6 +60,7 @@ api:
     successThreshold: 1
     timeoutSeconds: 2
   dbWaiter:
+    useExternalImage: true
     image:
       repository: willwill/wait-for-it
       tag: latest


### PR DESCRIPTION
Fixes #111.

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes

Add option to use the `waitfordb` command from the application Docker image, rather than pulling in a separate image for this purpose.

## How did you test this code?

```shell
# Default behaviour
$ helm -n flagsmith get values flagsmith-test -o json | jq .api.dbWaiter.useExternalImage
null
# Still uses wait-for-it image
$ kubectl -n flagsmith get deployments.apps -o json | jq -r '[(.items[] | (.spec.template.spec.initContainers // []) | .[].image)] | unique | .[]' 
flagsmith/flagsmith-api:2.42.1
willwill/wait-for-it:latest
...
# With new flag set
$ helm -n flagsmith get values flagsmith-test -o json | jq .api.dbWaiter.useExternalImage
false
# No just the flagsmith API image used
$ kubectl -n flagsmith get deployments.apps -o json | jq -r '[(.items[] | (.spec.template.spec.initContainers // []) | .[].image)] | unique | .[]' 
flagsmith/flagsmith-api:2.42.1
```

Some considerations:
- default behaviour remains the same
    - this is so users of Flagsmith that do not have `waitfordb` (believe this is <2.42.0) but using the new chart don't get an error
- still has a `wait-for-db` init container, rather than relying on the use of `waitfordb` in `run-docker.sh` for `migrate` and `serve`
    - this is so the value of `api.dbWaiter.timeoutSeconds` can be supplied to the command