### PR TITLE
fix!: remove ability to specify ingress paths (#138)

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.18.1
+version: 0.19.0
 appVersion: 2.42.1
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/ingress-api.yaml
+++ b/charts/flagsmith/templates/ingress-api.yaml
@@ -36,11 +36,10 @@ spec:
   {{- end }}
   rules:
     {{- range .Values.ingress.api.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ . | quote }}
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ . }}
+          - path: /
             {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
             backend:
@@ -53,6 +52,5 @@ spec:
               serviceName: {{ $fullName }}-api
               servicePort: {{ $svcPort }}
             {{- end }}
-          {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/flagsmith/templates/ingress-frontend.yaml
+++ b/charts/flagsmith/templates/ingress-frontend.yaml
@@ -36,11 +36,10 @@ spec:
   {{- end }}
   rules:
     {{- range .Values.ingress.frontend.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ . | quote }}
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ . }}
+          - path: /
             {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
             backend:
@@ -53,6 +52,5 @@ spec:
               serviceName: {{ $fullName }}-frontend
               servicePort: {{ $svcPort }}
             {{- end }}
-          {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -290,8 +290,7 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     hosts:
-      - host: chart-example.local
-        paths: []
+      - chart-example.local
     tls: []
     #  - secretName: chart-example-tls
     #    hosts:
@@ -303,8 +302,7 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     hosts:
-      - host: chart-example.local
-        paths: []
+      - chart-example.local
     tls: []
     #  - secretName: chart-example-tls
     #    hosts:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes

This PR removes the ability to set custom paths for ingresses (issue #138). 

## How did you test this code?

Deployed it on a local cluster with ingresses enabled.