### PR TITLE
Bump appVersion 2.57.0

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -3,7 +3,7 @@ name: flagsmith
 description: Flagsmith
 type: application
 version: 0.19.0
-appVersion: 2.42.1
+appVersion: 2.57.0
 dependencies:
   - name: postgresql
     repository: https://charts.helm.sh/stable

--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.19.0
+version: 0.20.0
 appVersion: 2.57.0
 dependencies:
   - name: postgresql


### PR DESCRIPTION
## Changes

Bump the appVersion in the chart templates.

## How did you test this code?

2.57.0 is currently running in SaaS production and well tested. 
