### PR TITLE
fix: revert pathing changes to API Ingress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ venv/
 .vscode
 charts/*/charts
 .direnv
+.idea/

--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.20.0
+version: 0.21.0
 appVersion: 2.57.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/ingress-api.yaml
+++ b/charts/flagsmith/templates/ingress-api.yaml
@@ -49,10 +49,10 @@ spec:
                 port: 
                   number: {{ $svcPort }}
             {{- else }}
-          {{- end }}
             backend:
               serviceName: {{ $fullName }}-api
               servicePort: {{ $svcPort }}
             {{- end }}
+          {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/flagsmith/templates/ingress-api.yaml
+++ b/charts/flagsmith/templates/ingress-api.yaml
@@ -36,10 +36,11 @@ spec:
   {{- end }}
   rules:
     {{- range .Values.ingress.api.hosts }}
-    - host: {{ . | quote }}
+    - host: {{ .host | quote }}
       http:
         paths:
-          - path: /
+          {{- range .paths }}
+          - path: {{ . }}
             {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
             backend:
@@ -48,6 +49,7 @@ spec:
                 port: 
                   number: {{ $svcPort }}
             {{- else }}
+          {{- end }}
             backend:
               serviceName: {{ $fullName }}-api
               servicePort: {{ $svcPort }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -302,7 +302,8 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     hosts:
-      - chart-example.local
+      - host: chart-example.local
+        paths: [ ]
     tls: []
     #  - secretName: chart-example-tls
     #    hosts:


### PR DESCRIPTION
PR #139 correctly fixed a pathing issue for the front-end ingress, but also made the same changes to the API server ingress in order to maintain consistency between the two. However, changing the ingress in the latter case was unnecessary and broke deployments that used specialized paths for the API server (e.g. using rewrites). This PR reverts the changes for the API server ingress and leaves the changes to the front-end ingress untouched.

Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [ ] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes

- Reverted changes to the API server ingress

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

_Please describe._
