### PR TITLE
fix: allow using influxDB credentials from existing secret

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.22.0
+version: 0.22.1
 appVersion: 2.57.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/_api_environment.yaml
+++ b/charts/flagsmith/templates/_api_environment.yaml
@@ -28,8 +28,13 @@
 - name: INFLUXDB_TOKEN
   valueFrom:
     secretKeyRef:
+      {{- if .Values.influxdb2.adminUser.existingSecret }}
+      name: {{ .Values.influxdb2.adminUser.existingSecret }}
+      key: admin-token
+      {{- else }}
       name: {{ template "flagsmith.influxdb.fullname" . }}-auth
       key: admin-token
+      {{- end }}
 {{- else if .Values.influxdbExternal.enabled }}
 - name: INFLUXDB_URL
   value: {{ .Values.influxdbExternal.url | required "Must specify a URL for an external InfluxDB" }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -246,6 +246,10 @@ influxdb2:
     ## Or fill any of these values to use fixed values.
     password: ''
     token: ''
+    ## The password and token are obtained from an existing secret. The expected
+    ## keys are `admin-password` and `admin-token`.
+    ## If set, the password and token values above are ignored.
+    existingSecret: null
   persistence:
     enabled: false
     # storageClass: "-"


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes

Allows using the credentials of influxDB(not external) from from an existing k8s secret.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

1. I have checked that it is possible in dependent chart: https://github.com/influxdata/helm-charts/blob/3c10c43fa0b5a87bf03a70db59ce700665da0997/charts/influxdb2/values.yaml#L109 
2. I ran:
`helm template flagsmith-test .` from the charts/flagsmith directory and verified that the default behavior still persist
3. Finally, I ran:
`helm template flagsmith-test . --set influxdb2.adminUser.existingSecret=influxdb-secret` and verified that in the API deployment uses existing secret.
