### PR TITLE
Support injection of extra init containers and containers

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.22.1
+version: 0.22.2
 appVersion: 2.57.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -103,6 +103,9 @@ spec:
           - name: influxdb-setup
             mountPath: /influxdb_setup/
 {{- end }}
+{{- with .Values.api.extraInitContainers }}
+{{- toYaml . | nindent 6 }}
+{{- end }}
       containers:
       - name: {{ .Chart.Name }}-api
         image: {{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default (printf "%s" .Chart.AppVersion) }}
@@ -134,6 +137,9 @@ spec:
           timeoutSeconds: {{ .Values.api.readinessProbe.timeoutSeconds }}
         resources:
 {{ toYaml .Values.api.resources | indent 10 }}
+{{- with .Values.api.extraContainers }}
+{{- toYaml . | nindent 6 }}
+{{- end }}
 {{- if .Values.api.influxdbSetup.enabled }}
       volumes:
         - name: influxdb-setup

--- a/charts/flagsmith/templates/deployment-frontend.yaml
+++ b/charts/flagsmith/templates/deployment-frontend.yaml
@@ -53,6 +53,10 @@ spec:
         {{- $securityContext = $securityContext | merge (omit .Values.frontend.defaultPodSecurityContext "enabled") }}
         {{- end }}
         {{- toYaml $securityContext | nindent 8 }}
+{{- with .Values.frontend.extraInitContainers }}
+      initContainers:
+{{- toYaml . | nindent 6 }}
+{{- end }}
       containers:
       - name: {{ .Chart.Name }}-frontend
         image: {{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag | default (printf "%s" .Chart.AppVersion) }}
@@ -82,4 +86,7 @@ spec:
           timeoutSeconds: {{ .Values.frontend.readinessProbe.timeoutSeconds }}
         resources:
 {{ toYaml .Values.frontend.resources | indent 10 }}
+{{- with .Values.frontend.extraContainers }}
+{{- toYaml . | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/charts/flagsmith/templates/deployment-pgbouncer.yaml
+++ b/charts/flagsmith/templates/deployment-pgbouncer.yaml
@@ -54,6 +54,10 @@ spec:
         {{- $securityContext = $securityContext | merge (omit .Values.pgbouncer.defaultPodSecurityContext "enabled") }}
         {{- end }}
         {{- toYaml $securityContext | nindent 8 }}
+{{- with .Values.pgbouncer.extraInitContainers }}
+      initContainers:
+{{- toYaml . | nindent 6 }}
+{{- end }}
       containers:
       - name: {{ .Chart.Name }}-pgbouncer
         image: {{ .Values.pgbouncer.image.repository }}:{{ .Values.pgbouncer.image.tag }}
@@ -122,4 +126,7 @@ spec:
           {{- toYaml $securityContext | nindent 10 }}
         resources:
 {{ toYaml .Values.pgbouncer.resources | indent 10 }}
+{{- with .Values.pgbouncer.extraContainers }}
+{{- toYaml . | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -57,6 +57,10 @@ spec:
         {{- $securityContext = $securityContext | merge (omit .Values.taskProcessor.defaultPodSecurityContext "enabled") }}
         {{- end }}
         {{- toYaml $securityContext | nindent 8 }}
+{{- with .Values.taskProcessor.extraInitContainers }}
+      initContainers:
+{{- toYaml . | nindent 6 }}
+{{- end }}
       containers:
       - name: {{ .Chart.Name }}-task-processor
         image: {{ .Values.taskProcessor.image.repository | default .Values.api.image.repository }}:{{ .Values.taskProcessor.image.tag | default .Values.api.image.tag | default .Chart.AppVersion }}
@@ -107,4 +111,7 @@ spec:
           timeoutSeconds: {{ .Values.taskProcessor.readinessProbe.timeoutSeconds }}
         resources:
 {{ toYaml .Values.taskProcessor.resources | indent 10 }}
+{{- with .Values.taskProcessor.extraContainers }}
+{{- toYaml . | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -74,6 +74,8 @@ api:
     prefix: flagsmith.api
   influxdbSetup:
     enabled: false
+  extraInitContainers: []
+  extraContainers: []
 
 frontend:
   # Set this to `false` to switch off the frontend (deployment,
@@ -120,6 +122,8 @@ frontend:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 10
+  extraInitContainers: []
+  extraContainers: []
 
 # See https://docs.flagsmith.com/deployment/task-processor
 taskProcessor:
@@ -170,6 +174,8 @@ taskProcessor:
     # runAsNonRoot: true  # TODO: enable this, conditional on tag semver
     # runAsUser: 1000
     # runAsGroup: 1000
+  extraInitContainers: []
+  extraContainers: []
 
 postgresql:
   enabled: true
@@ -234,6 +240,8 @@ pgbouncer:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 2
+  extraInitContainers: []
+  extraContainers: []
 
 influxdb2:
   enabled: true


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes

Resolves #149

This adds support for injection of abritrary init containers and containers to all the deployments covered by this helm chart. The value names used are `extraInitContainers` and `extraContainers` - various other helm charts use these names, so I've looked to use them too. Note that 3 of the deployments don't actually have init containers as standard, but IMO it seems sensible to use "extra" for consistency, and also in case there are requirements for init containers in the future.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

- I ran `helm template .` and inspected the output with none of the new values defined
- I ran `helm template .` and inspected the output with the new values defined, but empty arrays
- I ran `helm template .` and inspected the output with the new values defined and populated with example containers
- I ran `ct lint --config ct.yaml`
- Note that I haven't test applied anything to a k8s cluster 