### PR TITLE
Issue 159: Add common.label and common.annotations Helm parameters

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.25.0
+version: 0.26.0
 appVersion: 2.102.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.24.1
+version: 0.25.0
 appVersion: 2.99.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.22.3
+version: 0.23.0
 appVersion: 2.57.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/_helpers.tpl
+++ b/charts/flagsmith/templates/_helpers.tpl
@@ -36,6 +36,9 @@ Common labels
 */}}
 {{- define "flagsmith.labels" -}}
 helm.sh/chart: {{ include "flagsmith.chart" . }}
+{{- with .Values.commonLabels }}
+{{ . | toYaml }}
+{{- end }}
 {{ include "flagsmith.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
@@ -49,6 +52,25 @@ Selector labels
 {{- define "flagsmith.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "flagsmith.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+
+{{/*
+Common annotations
+*/}}
+{{- define "flagsmith.annotations" -}}
+{{- if and (hasKey . "customAnnotations") (hasKey . "context") -}}
+{{- with .context.Values.commonAnnotations }}
+{{ . | toYaml }}
+{{- end }}
+{{- with .context.customAnnotations }}
+{{ . | toYaml }}
+{{- end }}
+{{- else -}}
+{{- with .Values.commonAnnotations }}
+{{ . | toYaml }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/flagsmith/templates/_helpers.tpl
+++ b/charts/flagsmith/templates/_helpers.tpl
@@ -36,7 +36,7 @@ Common labels
 */}}
 {{- define "flagsmith.labels" -}}
 helm.sh/chart: {{ include "flagsmith.chart" . }}
-{{- with .Values.commonLabels }}
+{{- with .Values.common.labels }}
 {{ . | toYaml }}
 {{- end }}
 {{ include "flagsmith.selectorLabels" . }}
@@ -59,15 +59,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Common annotations
 */}}
 {{- define "flagsmith.annotations" -}}
-{{- if and (hasKey . "customAnnotations") (hasKey . "context") -}}
-{{- with .context.Values.commonAnnotations }}
+{{- if and (hasKey . "customAnnotations") (hasKey . "commonValues") -}}
+{{- with .commonValues.annotations }}
 {{ . | toYaml }}
 {{- end }}
-{{- with .context.customAnnotations }}
+{{- with .customAnnotations }}
 {{ . | toYaml }}
 {{- end }}
 {{- else -}}
-{{- with .Values.commonAnnotations }}
+{{- with .annotations }}
 {{ . | toYaml }}
 {{- end }}
 {{- end }}

--- a/charts/flagsmith/templates/configmap-influxdb-setup.yaml
+++ b/charts/flagsmith/templates/configmap-influxdb-setup.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "flagsmith.fullname" . }}-influxdb-setup
-  {{- $annotations := include "flagsmith.annotations" . }}
+  {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}
   annotations:
     {{- . | nindent 4 }}

--- a/charts/flagsmith/templates/configmap-influxdb-setup.yaml
+++ b/charts/flagsmith/templates/configmap-influxdb-setup.yaml
@@ -3,6 +3,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "flagsmith.fullname" . }}-influxdb-setup
+  {{- $annotations := include "flagsmith.annotations" . }}
+  {{- with $annotations }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
     app.kubernetes.io/component: influxdb-setup

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -2,6 +2,11 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "flagsmith.fullname" . }}-api
+  {{- $annotations := include "flagsmith.annotations" . }}
+  {{- with $annotations }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
     app.kubernetes.io/component: api
@@ -28,6 +33,9 @@ spec:
 {{ toYaml .Values.api.podAnnotations | nindent 8 }}
 {{- end }}
       labels:
+        {{- if .Values.commonLabels }}
+        {{- .Values.commonLabels  | toYaml | nindent 8 }}
+        {{- end }}
         {{- include "flagsmith.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: api
         {{- if .Values.api.podLabels }}

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "flagsmith.fullname" . }}-api
-  {{- $annotations := include "flagsmith.annotations" . }}
+  {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}
   annotations:
     {{- . | nindent 4 }}
@@ -33,8 +33,8 @@ spec:
 {{ toYaml .Values.api.podAnnotations | nindent 8 }}
 {{- end }}
       labels:
-        {{- if .Values.commonLabels }}
-        {{- .Values.commonLabels  | toYaml | nindent 8 }}
+        {{- if .Values.common.labels }}
+        {{- .Values.common.labels  | toYaml | nindent 8 }}
         {{- end }}
         {{- include "flagsmith.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: api

--- a/charts/flagsmith/templates/deployment-frontend.yaml
+++ b/charts/flagsmith/templates/deployment-frontend.yaml
@@ -3,6 +3,11 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "flagsmith.fullname" . }}
+  {{- $annotations := include "flagsmith.annotations" . }}
+  {{- with $annotations }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
     app.kubernetes.io/component: frontend
@@ -22,6 +27,9 @@ spec:
 {{ toYaml .Values.frontend.podAnnotations | indent 8 }}
       {{- end }}
       labels:
+        {{- if .Values.commonLabels }}
+        {{- .Values.commonLabels  | toYaml | nindent 8 }}
+        {{- end }}
         {{- include "flagsmith.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: frontend
         {{- if .Values.frontend.podLabels }}

--- a/charts/flagsmith/templates/deployment-frontend.yaml
+++ b/charts/flagsmith/templates/deployment-frontend.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "flagsmith.fullname" . }}
-  {{- $annotations := include "flagsmith.annotations" . }}
+  {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}
   annotations:
     {{- . | nindent 4 }}
@@ -27,8 +27,8 @@ spec:
 {{ toYaml .Values.frontend.podAnnotations | indent 8 }}
       {{- end }}
       labels:
-        {{- if .Values.commonLabels }}
-        {{- .Values.commonLabels  | toYaml | nindent 8 }}
+        {{- if .Values.common.labels }}
+        {{- .Values.common.labels  | toYaml | nindent 8 }}
         {{- end }}
         {{- include "flagsmith.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: frontend

--- a/charts/flagsmith/templates/deployment-pgbouncer.yaml
+++ b/charts/flagsmith/templates/deployment-pgbouncer.yaml
@@ -3,6 +3,11 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "flagsmith.fullname" . }}-pgbouncer
+  {{- $annotations := include "flagsmith.annotations" . }}
+  {{- with $annotations }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
     app.kubernetes.io/component: pgbouncer
@@ -23,6 +28,9 @@ spec:
 {{ toYaml .Values.pgbouncer.podAnnotations | nindent 8 }}
 {{- end }}
       labels:
+        {{- if .Values.commonLabels }}
+        {{- .Values.commonLabels  | toYaml | nindent 8 }}
+        {{- end }}
         {{- include "flagsmith.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: pgbouncer
         {{- if .Values.pgbouncer.podLabels }}

--- a/charts/flagsmith/templates/deployment-pgbouncer.yaml
+++ b/charts/flagsmith/templates/deployment-pgbouncer.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "flagsmith.fullname" . }}-pgbouncer
-  {{- $annotations := include "flagsmith.annotations" . }}
+  {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}
   annotations:
     {{- . | nindent 4 }}
@@ -28,8 +28,8 @@ spec:
 {{ toYaml .Values.pgbouncer.podAnnotations | nindent 8 }}
 {{- end }}
       labels:
-        {{- if .Values.commonLabels }}
-        {{- .Values.commonLabels  | toYaml | nindent 8 }}
+        {{- if .Values.common.labels }}
+        {{- .Values.common.labels  | toYaml | nindent 8 }}
         {{- end }}
         {{- include "flagsmith.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: pgbouncer

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -3,6 +3,11 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "flagsmith.fullname" . }}-task-processor
+  {{- $annotations := include "flagsmith.annotations" . }}
+  {{- with $annotations }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
     app.kubernetes.io/component: task-processor
@@ -23,6 +28,9 @@ spec:
 {{ toYaml .Values.taskProcessor.podAnnotations | nindent 8 }}
 {{- end }}
       labels:
+        {{- if .Values.commonLabels }}
+        {{- .Values.commonLabels  | toYaml | nindent 8 }}
+        {{- end }}
         {{- include "flagsmith.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: task-processor
         {{- if .Values.taskProcessor.podLabels }}

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "flagsmith.fullname" . }}-task-processor
-  {{- $annotations := include "flagsmith.annotations" . }}
+  {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}
   annotations:
     {{- . | nindent 4 }}
@@ -28,8 +28,8 @@ spec:
 {{ toYaml .Values.taskProcessor.podAnnotations | nindent 8 }}
 {{- end }}
       labels:
-        {{- if .Values.commonLabels }}
-        {{- .Values.commonLabels  | toYaml | nindent 8 }}
+        {{- if .Values.common.labels }}
+        {{- .Values.common.labels  | toYaml | nindent 8 }}
         {{- end }}
         {{- include "flagsmith.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: task-processor

--- a/charts/flagsmith/templates/ingress-api.yaml
+++ b/charts/flagsmith/templates/ingress-api.yaml
@@ -16,7 +16,7 @@ metadata:
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
     app.kubernetes.io/component: api
-  {{- $annotations := include "flagsmith.annotations" ( dict "customAnnotations" .Values.ingress.api.annotations "context" . ) }}
+  {{- $annotations := include "flagsmith.annotations" ( dict "customAnnotations" .Values.ingress.api.annotations "commonValues" .Values.common ) }}
   {{- with $annotations }}
   annotations:
     {{- . | nindent 4 }}

--- a/charts/flagsmith/templates/ingress-api.yaml
+++ b/charts/flagsmith/templates/ingress-api.yaml
@@ -16,9 +16,10 @@ metadata:
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
     app.kubernetes.io/component: api
-  {{- with .Values.ingress.api.annotations }}
+  {{- $annotations := include "flagsmith.annotations" ( dict "customAnnotations" .Values.ingress.api.annotations "context" . ) }}
+  {{- with $annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- . | nindent 4 }}
   {{- end }}
 spec:
 {{- with .Values.ingress.api.ingressClassName }}

--- a/charts/flagsmith/templates/ingress-frontend.yaml
+++ b/charts/flagsmith/templates/ingress-frontend.yaml
@@ -16,7 +16,7 @@ metadata:
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
     app.kubernetes.io/component: frontend
-  {{- $annotations := include "flagsmith.annotations" ( dict "customAnnotations" .Values.ingress.frontend.annotations "context" . ) }}
+  {{- $annotations := include "flagsmith.annotations" ( dict "customAnnotations" .Values.ingress.frontend.annotations "commonValues" .Values.common ) }}
   {{- with $annotations }}
   annotations:
     {{- . | nindent 4 }}

--- a/charts/flagsmith/templates/ingress-frontend.yaml
+++ b/charts/flagsmith/templates/ingress-frontend.yaml
@@ -16,9 +16,10 @@ metadata:
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
     app.kubernetes.io/component: frontend
-  {{- with .Values.ingress.frontend.annotations }}
+  {{- $annotations := include "flagsmith.annotations" ( dict "customAnnotations" .Values.ingress.frontend.annotations "context" . ) }}
+  {{- with $annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- . | nindent 4 }}
   {{- end }}
 spec:
 {{- with .Values.ingress.frontend.ingressClassName }}

--- a/charts/flagsmith/templates/routes-api.yaml
+++ b/charts/flagsmith/templates/routes-api.yaml
@@ -4,6 +4,11 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: flagsmith-api
+  {{- $annotations := include "flagsmith.annotations" . }}
+  {{- with $annotations }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
     app.kubernetes.io/component: api

--- a/charts/flagsmith/templates/routes-api.yaml
+++ b/charts/flagsmith/templates/routes-api.yaml
@@ -4,7 +4,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: flagsmith-api
-  {{- $annotations := include "flagsmith.annotations" . }}
+  {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}
   annotations:
     {{- . | nindent 4 }}

--- a/charts/flagsmith/templates/routes-frontend.yaml
+++ b/charts/flagsmith/templates/routes-frontend.yaml
@@ -4,6 +4,11 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: flagsmith-frontend
+  {{- $annotations := include "flagsmith.annotations" . }}
+  {{- with $annotations }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
     app.kubernetes.io/component: frontend

--- a/charts/flagsmith/templates/routes-frontend.yaml
+++ b/charts/flagsmith/templates/routes-frontend.yaml
@@ -4,7 +4,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: flagsmith-frontend
-  {{- $annotations := include "flagsmith.annotations" . }}
+  {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}
   annotations:
     {{- . | nindent 4 }}

--- a/charts/flagsmith/templates/secrets-api.yaml
+++ b/charts/flagsmith/templates/secrets-api.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "flagsmith.fullname" . }}
-  {{- $annotations := include "flagsmith.annotations" . }}
+  {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}
   annotations:
     {{- . | nindent 4 }}

--- a/charts/flagsmith/templates/secrets-api.yaml
+++ b/charts/flagsmith/templates/secrets-api.yaml
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "flagsmith.fullname" . }}
+  {{- $annotations := include "flagsmith.annotations" . }}
+  {{- with $annotations }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
     app.kubernetes.io/component: api

--- a/charts/flagsmith/templates/secrets-influxdb-external.yaml
+++ b/charts/flagsmith/templates/secrets-influxdb-external.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  {{- $annotations := include "flagsmith.annotations" . }}
+  {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}
   annotations:
     {{- . | nindent 4 }}

--- a/charts/flagsmith/templates/secrets-influxdb-external.yaml
+++ b/charts/flagsmith/templates/secrets-influxdb-external.yaml
@@ -2,6 +2,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  {{- $annotations := include "flagsmith.annotations" . }}
+  {{- with $annotations }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
   name: {{ template "flagsmith.influxdb.fullname" . }}-external-auth

--- a/charts/flagsmith/templates/secrets-pgbouncer.yaml
+++ b/charts/flagsmith/templates/secrets-pgbouncer.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "flagsmith.fullname" . }}-pgbouncer
-  {{- $annotations := include "flagsmith.annotations" . }}
+  {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}
   annotations:
     {{- . | nindent 4 }}

--- a/charts/flagsmith/templates/secrets-pgbouncer.yaml
+++ b/charts/flagsmith/templates/secrets-pgbouncer.yaml
@@ -3,6 +3,11 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "flagsmith.fullname" . }}-pgbouncer
+  {{- $annotations := include "flagsmith.annotations" . }}
+  {{- with $annotations }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
     app.kubernetes.io/component: pgbouncer

--- a/charts/flagsmith/templates/service-api.yaml
+++ b/charts/flagsmith/templates/service-api.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "flagsmith.fullname" . }}-api
-  {{- $annotations := include "flagsmith.annotations" ( dict "customAnnotations" .Values.service.api.annotations "context" . ) }}
+  {{- $annotations := include "flagsmith.annotations" ( dict "customAnnotations" .Values.service.api.annotations "commonValues" .Values.common ) }}
   {{- with $annotations }}
   annotations:
     {{- . | nindent 4 }}

--- a/charts/flagsmith/templates/service-api.yaml
+++ b/charts/flagsmith/templates/service-api.yaml
@@ -2,9 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "flagsmith.fullname" . }}-api
-  {{- with .Values.service.api.annotations }}
+  {{- $annotations := include "flagsmith.annotations" ( dict "customAnnotations" .Values.service.api.annotations "context" . ) }}
+  {{- with $annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- . | nindent 4 }}
   {{- end }}
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}

--- a/charts/flagsmith/templates/service-frontend.yaml
+++ b/charts/flagsmith/templates/service-frontend.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- $annotations := include "flagsmith.annotations" ( dict "customAnnotations" .Values.service.frontend.annotations "context" . ) }}
+  {{- $annotations := include "flagsmith.annotations" ( dict "customAnnotations" .Values.service.frontend.annotations "commonValues" .Values.common ) }}
   {{- with $annotations }}
   annotations:
     {{- . | nindent 4 }}

--- a/charts/flagsmith/templates/service-frontend.yaml
+++ b/charts/flagsmith/templates/service-frontend.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "flagsmith.fullname" . }}-frontend
-  {{- with .Values.service.api.annotations }}
+  {{- $annotations := include "flagsmith.annotations" ( dict "customAnnotations" .Values.service.api.annotations "context" . ) }}
+  {{- with $annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- . | nindent 4 }}
   {{- end }}
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}

--- a/charts/flagsmith/templates/service-frontend.yaml
+++ b/charts/flagsmith/templates/service-frontend.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- $annotations := include "flagsmith.annotations" ( dict "customAnnotations" .Values.service.api.annotations "context" . ) }}
+  {{- $annotations := include "flagsmith.annotations" ( dict "customAnnotations" .Values.service.frontend.annotations "context" . ) }}
   {{- with $annotations }}
   annotations:
     {{- . | nindent 4 }}

--- a/charts/flagsmith/templates/service-frontend.yaml
+++ b/charts/flagsmith/templates/service-frontend.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  name: {{ include "flagsmith.fullname" . }}-frontend
   {{- $annotations := include "flagsmith.annotations" ( dict "customAnnotations" .Values.service.frontend.annotations "commonValues" .Values.common ) }}
   {{- with $annotations }}
   annotations:

--- a/charts/flagsmith/templates/service-pgbouncer.yaml
+++ b/charts/flagsmith/templates/service-pgbouncer.yaml
@@ -3,6 +3,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "flagsmith.fullname" . }}-pgbouncer
+  {{- $annotations := include "flagsmith.annotations" . }}
+  {{- with $annotations }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
     app.kubernetes.io/component: pgbouncer

--- a/charts/flagsmith/templates/service-pgbouncer.yaml
+++ b/charts/flagsmith/templates/service-pgbouncer.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "flagsmith.fullname" . }}-pgbouncer
-  {{- $annotations := include "flagsmith.annotations" . }}
+  {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}
   annotations:
     {{- . | nindent 4 }}

--- a/charts/flagsmith/templates/tests/test-api-http-health.yaml
+++ b/charts/flagsmith/templates/tests/test-api-http-health.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "flagsmith.labels" . | nindent 4 }}
     app.kubernetes.io/component: test-api-http-health
   annotations:
-    {{- $annotations := include "flagsmith.annotations" . }}
+    {{- $annotations := include "flagsmith.annotations" .Values.common }}
     {{- if $annotations }}
     {{- $annotations | nindent 4 }}
     {{- end }}

--- a/charts/flagsmith/templates/tests/test-api-http-health.yaml
+++ b/charts/flagsmith/templates/tests/test-api-http-health.yaml
@@ -7,6 +7,10 @@ metadata:
     {{- include "flagsmith.labels" . | nindent 4 }}
     app.kubernetes.io/component: test-api-http-health
   annotations:
+    {{- $annotations := include "flagsmith.annotations" . }}
+    {{- if $annotations }}
+    {{- $annotations | nindent 4 }}
+    {{- end }}
     "helm.sh/hook": test
 spec:
   containers:

--- a/charts/flagsmith/templates/tests/test-e2e.yaml
+++ b/charts/flagsmith/templates/tests/test-e2e.yaml
@@ -8,6 +8,10 @@ metadata:
     {{- include "flagsmith.labels" . | nindent 4 }}
     app.kubernetes.io/component: test-e2e
   annotations:
+    {{- $annotations := include "flagsmith.annotations" . }}
+    {{- if $annotations }}
+    {{- $annotations | nindent 4 }}
+    {{- end }}
     "helm.sh/hook": test
 spec:
 {{- if .Values.api.image.imagePullSecrets }}

--- a/charts/flagsmith/templates/tests/test-e2e.yaml
+++ b/charts/flagsmith/templates/tests/test-e2e.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "flagsmith.labels" . | nindent 4 }}
     app.kubernetes.io/component: test-e2e
   annotations:
-    {{- $annotations := include "flagsmith.annotations" . }}
+    {{- $annotations := include "flagsmith.annotations" .Values.common }}
     {{- if $annotations }}
     {{- $annotations | nindent 4 }}
     {{- end }}

--- a/charts/flagsmith/templates/tests/test-frontend-http.yaml
+++ b/charts/flagsmith/templates/tests/test-frontend-http.yaml
@@ -8,6 +8,10 @@ metadata:
     {{- include "flagsmith.labels" . | nindent 4 }}
     app.kubernetes.io/component: test-frontend-http
   annotations:
+    {{- $annotations := include "flagsmith.annotations" . }}
+    {{- if $annotations }}
+    {{- $annotations | nindent 4 }}
+    {{- end }}
     "helm.sh/hook": test
 spec:
   containers:

--- a/charts/flagsmith/templates/tests/test-frontend-http.yaml
+++ b/charts/flagsmith/templates/tests/test-frontend-http.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "flagsmith.labels" . | nindent 4 }}
     app.kubernetes.io/component: test-frontend-http
   annotations:
-    {{- $annotations := include "flagsmith.annotations" . }}
+    {{- $annotations := include "flagsmith.annotations" .Values.common }}
     {{- if $annotations }}
     {{- $annotations | nindent 4 }}
     {{- end }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -1,3 +1,9 @@
+# Annotations to add to all the resources deployed by this chart
+commonLabels: {}
+
+# Labels to add to all the resources deployed by this chart
+commonAnnotations: {}
+
 api:
   image:
     repository: flagsmith/flagsmith-api

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -1,8 +1,8 @@
-# Annotations to add to all the resources deployed by this chart
-commonLabels: {}
-
-# Labels to add to all the resources deployed by this chart
-commonAnnotations: {}
+common:
+  # Labels to add to all the resources deployed by this chart
+  labels: {}
+  # Annotations to add to all the resources deployed by this chart
+  annotations: {}
 
 api:
   image:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes
### Features
* Adding `commonLabels` and `commonAnnotations` field to the values file
* Updating `flagsmith.labels` to use `commonLabels` if provided
* Adding `flagsmith.annotations` to use `commonannotations` if provided
* Adding annotations to places where they were missed
* Update existing annotations to add `commonAnnotations` as well

### Fixes
* Fix wrong annotations used in `service-fronend.yaml` file

## How did you test this code?

I ran `helm install` with different parameters to verify that new labels and annotations are added only if needed.

