### PR TITLE
fix(task-processor): add run by processor

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,8 +2,13 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
+<<<<<<< HEAD
 version: 0.23.0
 appVersion: 2.96.0
+=======
+version: 0.22.4
+appVersion: 2.57.0
+>>>>>>> 610affd (Bump chart version)
 dependencies:
   - name: postgresql
     repository: https://charts.helm.sh/stable

--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,13 +2,8 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-<<<<<<< HEAD
-version: 0.23.0
+version: 0.23.1
 appVersion: 2.96.0
-=======
-version: 0.22.4
-appVersion: 2.57.0
->>>>>>> 610affd (Bump chart version)
 dependencies:
   - name: postgresql
     repository: https://charts.helm.sh/stable

--- a/charts/flagsmith/templates/_task_processor_environment.yaml
+++ b/charts/flagsmith/templates/_task_processor_environment.yaml
@@ -1,0 +1,3 @@
+{{ include (print $.Template.BasePath "/_api_environment.yaml") . }}
+- name: "RUN_BY_PROCESSOR"
+  value: "1"

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -66,6 +66,7 @@ spec:
         image: {{ .Values.taskProcessor.image.repository | default .Values.api.image.repository }}:{{ .Values.taskProcessor.image.tag | default .Values.api.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.taskProcessor.image.imagePullPolicy | default .Values.api.image.imagePullPolicy }}
         command:
+          - RUN_BY_PROCESSOR=1
           - python
           - manage.py
         args:

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -66,7 +66,6 @@ spec:
         image: {{ .Values.taskProcessor.image.repository | default .Values.api.image.repository }}:{{ .Values.taskProcessor.image.tag | default .Values.api.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.taskProcessor.image.imagePullPolicy | default .Values.api.image.imagePullPolicy }}
         command:
-          - RUN_BY_PROCESSOR=1
           - python
           - manage.py
         args:
@@ -87,7 +86,7 @@ spec:
           - --queuepopsize
           - {{ . | quote }}
 {{- end }}
-        env: {{ include (print $.Template.BasePath "/_api_environment.yaml") . | nindent 8 }}
+        env: {{ include (print $.Template.BasePath "/_task_processor_environment.yaml") . | nindent 8 }}
         livenessProbe:
           failureThreshold: {{ .Values.taskProcessor.livenessProbe.failureThreshold }}
           exec:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes

Adds the RUN_BY_PROCESSOR environment variable to the task processor. 

This is a temporary fix until we can complete [this issue](https://github.com/Flagsmith/flagsmith/issues/3317) in the main repository and replace the run command here with a call to the run-docker script instead. 

## How did you test this code?

Ran the chart locally and confirmed that the `RUN_BY_PROCESSOR` variable is set in the task processor pods and all pods come up healthy. 
