### PR TITLE
chore: Use run-docker script for task processor

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.23.2
+version: 0.23.3
 appVersion: 2.96.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -3,7 +3,7 @@ name: flagsmith
 description: Flagsmith
 type: application
 version: 0.23.3
-appVersion: 2.96.0
+appVersion: 2.96.1
 dependencies:
   - name: postgresql
     repository: https://charts.helm.sh/stable

--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.23.3
+version: 0.23.4
 appVersion: 2.96.1
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.24.0
+version: 0.24.1
 appVersion: 2.99.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/_task_processor_environment.yaml
+++ b/charts/flagsmith/templates/_task_processor_environment.yaml
@@ -1,3 +1,17 @@
 {{ include (print $.Template.BasePath "/_api_environment.yaml") . }}
-- name: "RUN_BY_PROCESSOR"
-  value: "1"
+{{- if .Values.taskProcessor.sleepIntervalMs }}
+- name: TASK_PROCESSOR_SLEEP_INTERVAL
+  value: {{ .Values.taskProcessor.sleepIntervalMs | quote }}
+{{- end }}
+{{- if .Values.taskProcessor.numThreads }}
+- name: TASK_PROCESSOR_NUM_THREADS
+  value: {{ .Values.taskProcessor.numThreads | quote }}
+{{- end }}
+{{- if .Values.taskProcessor.gracePeriodMs }}
+- name: TASK_PROCESSOR_GRACE_PERIOD_MS
+  value: {{ .Values.taskProcessor.gracePeriodMs | quote }}
+{{- end }}
+{{- if .Values.taskProcessor.queuePopSize }}
+- name: TASK_PROCESSOR_QUEUE_POP_SIZE
+  value: {{ .Values.taskProcessor.queuePopSize | quote }}
+{{- end }}

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -66,26 +66,9 @@ spec:
         image: {{ .Values.taskProcessor.image.repository | default .Values.api.image.repository }}:{{ .Values.taskProcessor.image.tag | default .Values.api.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.taskProcessor.image.imagePullPolicy | default .Values.api.image.imagePullPolicy }}
         command:
-          - python
-          - manage.py
+          - ./scripts/run-docker.sh
         args:
-          - runprocessor
-{{- with .Values.taskProcessor.sleepIntervalMs }}
-          - --sleepintervalms
-          - {{ . | quote }}
-{{- end }}
-{{- with .Values.taskProcessor.numThreads }}
-          - --numthreads
-          - {{ . | quote }}
-{{- end }}
-{{- with .Values.taskProcessor.gracePeriodMs }}
-          - --graceperiodms
-          - {{ . | quote }}
-{{- end }}
-{{- with .Values.taskProcessor.queuePopSize }}
-          - --queuepopsize
-          - {{ . | quote }}
-{{- end }}
+          - run-task-processor
         env: {{ include (print $.Template.BasePath "/_task_processor_environment.yaml") . | nindent 8 }}
         livenessProbe:
           failureThreshold: {{ .Values.taskProcessor.livenessProbe.failureThreshold }}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes

Uses the run-docker.sh script to run the task processor instead of manually calling `python manage.py runprocessor`. 

## How did you test this code?

Ran the chart locally and tested changing each of the initialisation parameterts. 
