### PR TITLE
feat: Migrate job, waiter deprecation, togglable init container

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.26.0
+version: 0.27.0
 appVersion: 2.102.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -68,37 +68,13 @@ spec:
         {{- end }}
         {{- toYaml $securityContext | nindent 8 }}
       initContainers:
-{{- if eq .Values.databaseExternal.enabled false }}
-      - name: wait-for-db
-{{- if .Values.api.dbWaiter.useExternalImage }}
-        image: {{ .Values.api.dbWaiter.image.repository }}:{{ .Values.api.dbWaiter.image.tag }}
-        imagePullPolicy: {{ .Values.api.dbWaiter.image.imagePullPolicy }}
-        command:
-          - /wait-for-it.sh
-          {{- if .Values.pgbouncer.enabled }}
-          - --host={{ template "flagsmith.pgbouncer.hostname" . }}
-          {{- else }}
-          - --host={{ template "flagsmith.postgres.hostname" . }}
-          {{- end }}
-          - --port=5432
-          - --timeout={{ .Values.api.dbWaiter.timeoutSeconds }}
-{{- else }}
-        image: {{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default (printf "%s" .Chart.AppVersion) }}
-        imagePullPolicy: {{ .Values.api.image.imagePullPolicy }}
-        command:
-          - python
-          - manage.py
-          - waitfordb
-          - --waitfor
-          - {{ .Values.api.dbWaiter.timeoutSeconds | quote }}
-        env: {{ include (print $.Template.BasePath "/_api_environment.yaml") . | nindent 8 }}
-{{- end }}
-{{- end }}
+{{- if .Values.api.enableMigrateDbInitContainer }}
       - name: migrate-db
         image: {{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default (printf "%s" .Chart.AppVersion) }}
         imagePullPolicy: {{ .Values.api.image.imagePullPolicy }}
         args: ["migrate"]
         env: {{ include (print $.Template.BasePath "/_api_environment.yaml") . | nindent 8 }}
+{{- end }}
 {{- if .Values.api.influxdbSetup.enabled }}
       - name: influxdb-setup
         image: {{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default (printf "%s" .Chart.AppVersion) }}

--- a/charts/flagsmith/templates/jobs-migrate-db.yaml
+++ b/charts/flagsmith/templates/jobs-migrate-db.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.jobs.migrateDb.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "flagsmith.fullname" . }}-migrate-db
+  {{- $annotations := include "flagsmith.annotations" .Values.common }}
+  {{- with $annotations }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "flagsmith.labels" . | nindent 4 }}
+    app.kubernetes.io/component: job-migrate-db
+spec:
+  ttlSecondsAfterFinished: {{ .Values.jobs.migrateDb.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      {{- if .Values.jobs.migrateDb.jobAnnotations }}
+      annotations:
+{{ toYaml .Values.jobs.migrateDb.jobAnnotations | indent 8 }}
+      {{- end }}
+      labels:
+        {{- if .Values.common.labels }}
+        {{- .Values.common.labels  | toYaml | nindent 8 }}
+        {{- end }}
+        {{- include "flagsmith.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: job-migrate-db
+        {{- if .Values.jobs.migrateDb.podLabels }}
+{{ toYaml .Values.jobs.migrateDb.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      restartPolicy: {{ .Values.jobs.migrateDb.restartPolicy }}
+      {{- if .Values.jobs.migrateDb.affinity }}
+      affinity:
+{{ toYaml .Values.jobs.migrateDb.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.jobs.migrateDb.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.jobs.migrateDb.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.jobs.migrateDb.tolerations }}
+      tolerations:
+{{ toYaml .Values.jobs.migrateDb.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.api.image.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.api.image.imagePullSecrets | indent 8 }}
+      {{- end }}
+      securityContext:
+        {{- $securityContext := .Values.jobs.migrateDb.podSecurityContext | default (dict) | deepCopy }}
+        {{- if .Values.jobs.migrateDb.defaultPodSecurityContext.enabled }}
+        {{- $securityContext = $securityContext | merge (omit .Values.jobs.migrateDb.defaultPodSecurityContext "enabled") }}
+        {{- end }}
+        {{- toYaml $securityContext | nindent 8 }}
+      {{- if .Values.jobs.migrateDb.shareProcessNamespace }}
+      shareProcessNamespace: true
+      {{- end }}
+      containers:
+      - name: migrate-db
+        image: {{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default (printf "%s" .Chart.AppVersion) }}
+        imagePullPolicy: {{ .Values.api.image.imagePullPolicy }}
+        {{- if .Values.jobs.migrateDb.command }}
+        command: {{ toYaml .Values.jobs.migrateDb.command | nindent 8 }}
+        {{- end }}
+        {{- if .Values.jobs.migrateDb.args }}
+        args: {{ toYaml .Values.jobs.migrateDb.args | nindent 8 }}
+        {{- else }}
+        args: ["migrate"]
+        {{- end }}
+        env: {{ include (print $.Template.BasePath "/_api_environment.yaml") . | nindent 8 }}
+{{- with .Values.jobs.migrateDb.extraContainers }}
+{{- toYaml . | nindent 6 }}
+{{- end }}
+      volumes:
+{{- with .Values.jobs.migrateDb.extraVolumes }}
+{{- toYaml . | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -65,13 +65,6 @@ api:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 2
-  dbWaiter:
-    useExternalImage: true
-    image:
-      repository: willwill/wait-for-it
-      tag: latest
-      imagePullPolicy: IfNotPresent
-    timeoutSeconds: 30
   statsd:
     enabled: false
     host: null
@@ -84,6 +77,7 @@ api:
   extraContainers: []
   logging:
     format: generic # options are generic or json.
+  enableMigrateDbInitContainer: true
 
 frontend:
   # Set this to `false` to switch off the frontend (deployment,
@@ -329,6 +323,19 @@ ingress:
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
+
+jobs:
+  migrateDb:
+    enabled: false
+    ttlSecondsAfterFinished: 3600
+    restartPolicy: OnFailure
+    defaultPodSecurityContext:
+      enabled: true
+      # runAsNonRoot: true
+    extraContainers: []
+    extraVolumes: []
+    command: []
+    args: []
 
 # These tests just make non-destructive requests to the services in
 # the cluster. Enabling this and running helm test is safe.


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes

This PR does the following:
- Removes the wait-for-db init container as Flagsmith's entrypoint integrates this functionality.
- Adds an ability to remove the `migrate-db` init container.
- Adds an ability to deploy a `migrate-db` Kubernetes job, and customise it with extra containers and volumes.

This, along with #184, helps the chart users to add containers responsible for database connectivity, such as Google's `cloud-sql-proxy`. 

## How did you test this code?

This code now works as part of one of our enterprise on-premise deployments.