### PR TITLE
release: v0.30.0

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.29.0
+version: 0.30.0
 appVersion: 2.104.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.28.0
+version: 0.29.0
 appVersion: 2.103.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -42,6 +42,9 @@ spec:
 {{ toYaml .Values.api.podLabels | indent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.api.shareProcessNamespace }}
+      shareProcessNamespace: true
+      {{- end }}
       {{- if .Values.api.affinity }}
       affinity:
 {{ toYaml .Values.api.affinity | indent 8 }}

--- a/charts/flagsmith/templates/deployment-frontend.yaml
+++ b/charts/flagsmith/templates/deployment-frontend.yaml
@@ -36,6 +36,9 @@ spec:
 {{ toYaml .Values.frontend.podLabels | indent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.frontend.shareProcessNamespace }}
+      shareProcessNamespace: true
+      {{- end }}
       {{- if .Values.frontend.affinity }}
       affinity:
 {{ toYaml .Values.frontend.affinity | indent 8 }}

--- a/charts/flagsmith/templates/deployment-pgbouncer.yaml
+++ b/charts/flagsmith/templates/deployment-pgbouncer.yaml
@@ -37,6 +37,9 @@ spec:
 {{ toYaml .Values.pgbouncer.podLabels | indent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.pgbouncer.shareProcessNamespace }}
+      shareProcessNamespace: true
+      {{- end }}
       {{- if .Values.pgbouncer.affinity }}
       affinity:
 {{ toYaml .Values.pgbouncer.affinity | indent 8 }}

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -37,6 +37,9 @@ spec:
 {{ toYaml .Values.taskProcessor.podLabels | indent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.taskProcessor.shareProcessNamespace }}
+      shareProcessNamespace: true
+      {{- end }}
       {{- if .Values.taskProcessor.affinity }}
       affinity:
 {{ toYaml .Values.taskProcessor.affinity | indent 8 }}

--- a/charts/flagsmith/templates/jobs-migrate-db.yaml
+++ b/charts/flagsmith/templates/jobs-migrate-db.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "flagsmith.fullname" . }}-migrate-db
+  name: {{ template "flagsmith.fullname" . }}-migrate-db-{{ .Release.Revision }}-{{ randAlphaNum 5 }}
   {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}
   annotations:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes

1. `migrate-db` job is now created with a unique suffix. This helps with the fact that k8s jobs are immutable and can not be updated in-place.
2. `shareProcessNamespace` container spec attribute is exposed to enable usage of tools like remote debuggers and profilers defined as additional pod containers.

## How did you test this code?

Tested with one of the private cloud customers' cluster.