### PR TITLE
fix(task-processor): the extraEnv where added in the wrong place

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.40.0
+version: 0.40.1
 appVersion: 2.115.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/_task_processor_environment.yaml
+++ b/charts/flagsmith/templates/_task_processor_environment.yaml
@@ -15,3 +15,7 @@
 - name: TASK_PROCESSOR_QUEUE_POP_SIZE
   value: {{ .Values.taskProcessor.queuePopSize | quote }}
 {{- end }}
+{{- range $envName, $envValue := .Values.taskProcessor.extraEnv }}
+- name: {{ $envName }}
+  value: {{ $envValue | quote }}
+{{- end }}

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -68,9 +68,6 @@ spec:
         {{- $securityContext = $securityContext | merge (omit .Values.taskProcessor.defaultPodSecurityContext "enabled") }}
         {{- end }}
         {{- toYaml $securityContext | nindent 8 }}
-      env:
-        {{- $mergedEnv := merge .Values.api.extraEnv .Values.taskProcessor.extraEnv }}
-        {{- toYaml $mergedEnv | nindent 8 }}
 {{- with .Values.taskProcessor.extraInitContainers }}
       initContainers:
 {{- toYaml . | nindent 6 }}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes
Fix bug introduced in thhis pr https://github.com/Flagsmith/flagsmith-charts/pull/187 

The environment variables added for the task processor should go inside the container that runs the task processor rather in the deployment template spec.

The task processor was already including the api environment so it was not necessary to add merge both `extraEnv`

Also the `extraEnv` keys and values were added as yaml (`key: value`), instead of the expected object with the `name` and `value` keys.

## How did you test this code?

I test it manually. With a values

```
api:
  extraEnv:
    ALLOW_REGISTRATION_WITHOUT_INVITE: false

taskProcessor:
  enabled: true
  extraEnv:
    foo: bar
```

The expected result in the api deployment, inside the `flagsmith-task-processor` container

```
env:
....
- name: ALLOW_REGISTRATION_WITHOUT_INVITE
  value: "false"
...
```

and in the task processor deployment, inside the `flagsmith-task-processor` container

```
env:
....
- name: ALLOW_REGISTRATION_WITHOUT_INVITE
  value: "false"
- name: foo
  value: bar
...
```

