### PR TITLE
Disable InfluxDB in values by default

### DIFF
--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -251,7 +251,7 @@ pgbouncer:
   extraVolumes: []
 
 influxdb2:
-  enabled: true
+  enabled: false
   adminUser:
     organization: 'influxdata'
     bucket: 'default'


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [ ] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes

We are no longer using InfluxDB as the default for all new Flagsmith deployments. Disabling it by default in Helm values removes a possible point of friction, for example for customers that require all container images be mirrored in internal repositories.

I understand this should only affect new deployments, but feel free to ignore or close this PR if it would cause any problems.

## How did you test this code?

Not tested directly, but validated this change live with a customer that requires all images to be sourced from internal repositories.
