### PR TITLE
feat: Add default user/organisation/project bootstrapping

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.42.0
+version: 0.43.0
 appVersion: 2.118.1
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/NOTES.txt
+++ b/charts/flagsmith/templates/NOTES.txt
@@ -9,6 +9,12 @@ kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "flagsmith.fulln
 
 Then access http://localhost:8080 in a browser.
 
+{{- if .Values.api.bootstrap.enabled }}
+To see the password reset link for pre-created admin user, run:
+
+kubectl -n {{ .Release.Namespace }} logs pods/{{ include "flagsmith.fullname" . }}-api -c bootstrap
+{{- end }}
+
 {{ if not (and .Values.ingress.frontend.enabled .Values.ingress.api.enabled) }}
 
 {{- $noIngressFor := (list) -}}
@@ -24,7 +30,7 @@ for information about how to gain web access to the application.
 
 {{- end }}
 
-{{- if not .Values.api.secretKey }}
+{{- if or (not .Values.api.secretKeyFromExistingSecret.enabled) (not .Values.api.secretKey) }}
 
 ######################################
 ##### Warning: no secret key set #####
@@ -32,8 +38,11 @@ for information about how to gain web access to the application.
 
 No secret key is set, a new one will be randomly generated at each
 deployment. For production systems, it is strongly recommended to
-generate a large random value and set it at `api.secretKey`. It must
-be kept secret.
+generate a large random value, store it in a secret, and set the following values:
+
+`api.secretKeyFromExistingSecret.enabled` to `true`
+`api.secretKeyFromExistingSecret.name` to secret name
+`api.secretKeyFromExistingSecret.key` to secret key
 
 See https://docs.flagsmith.com/deployment/locally-api#creating-a-secret-key
 {{- end }}

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -78,6 +78,26 @@ spec:
         args: ["migrate"]
         env: {{ include (print $.Template.BasePath "/_api_environment.yaml") . | nindent 8 }}
 {{- end }}
+{{- if .Values.api.bootstrap.enabled }}
+      - name: bootstrap
+        image: {{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default (printf "%s" .Chart.AppVersion) }}
+        imagePullPolicy: {{ .Values.api.image.imagePullPolicy }}
+        command: ["/bin/sh", "-c"]
+        args: ["python manage.py waitfordb && python manage.py bootstrap"]
+        env: {{ include (print $.Template.BasePath "/_api_environment.yaml") . | nindent 8 }}
+          {{- if .Values.api.bootstrap.adminEmail }}
+          - name: ADMIN_EMAIL
+            value: {{ .Values.api.bootstrap.adminEmail }}
+          {{- end }}
+          {{- if .Values.api.bootstrap.organisationName }}
+          - name: ORGANISATION_NAME
+            value: {{ .Values.api.bootstrap.organisationName }}
+          {{- end }}
+          {{- if .Values.api.bootstrap.projectName }}
+          - name: PROJECT_NAME
+            value: {{ .Values.api.bootstrap.projectName }}
+          {{- end }}
+{{- end }}
 {{- if .Values.api.influxdbSetup.enabled }}
       - name: influxdb-setup
         image: {{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default (printf "%s" .Chart.AppVersion) }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -79,6 +79,14 @@ api:
   logging:
     format: generic # options are generic or json.
   enableMigrateDbInitContainer: true
+  bootstrap:
+    # Set to `true` to create initial superuser, organisation, and project.
+    # If `adminEmail`, `organisationName` or `projectName` not set, defaults are used.
+    # Bootstrapping does nothing if app database is not empty.
+    enabled: false
+    adminEmail: null
+    organisationName: null
+    projectName: null
 
 frontend:
   # Set this to `false` to switch off the frontend (deployment,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes

Closes https://github.com/Flagsmith/flagsmith-charts/issues/96.

This adds a documented way to pre-create default user/organisation/project.

## How did you test this code?

Deployed to a local K8S cluster.