### PR TITLE
fix: Set  `ALLOW_ADMIN_INITIATION_VIA_CLI` when `bootstrap.enabled` is `true`

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.45.0
+version: 0.46.0
 appVersion: 2.120.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -85,6 +85,8 @@ spec:
         command: ["/bin/sh", "-c"]
         args: ["python manage.py waitfordb && python manage.py bootstrap"]
         env: {{ include (print $.Template.BasePath "/_api_environment.yaml") . | nindent 8 }}
+          - name: ALLOW_ADMIN_INITIATION_VIA_CLI
+            value: 'true'
           {{- if .Values.api.bootstrap.adminEmail }}
           - name: ADMIN_EMAIL
             value: {{ .Values.api.bootstrap.adminEmail }}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes

This _actually_ enables bootstrapping. 

## How did you test this code?

Deployed to local k8s cluster without any custom environment variables.