### PR TITLE
feat: Ability to specify `serviceAccountName`

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.45.0
+version: 0.46.0
 appVersion: 2.120.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -70,6 +70,9 @@ spec:
         {{- $securityContext = $securityContext | merge (omit .Values.api.defaultPodSecurityContext "enabled") }}
         {{- end }}
         {{- toYaml $securityContext | nindent 8 }}
+      {{- if .Values.api.serviceAccountName }}
+      serviceAccountName: {{ .Values.api.serviceAccountName }}
+      {{- end }}
       initContainers:
 {{- if .Values.api.enableMigrateDbInitContainer }}
       - name: migrate-db

--- a/charts/flagsmith/templates/deployment-frontend.yaml
+++ b/charts/flagsmith/templates/deployment-frontend.yaml
@@ -64,6 +64,9 @@ spec:
         {{- $securityContext = $securityContext | merge (omit .Values.frontend.defaultPodSecurityContext "enabled") }}
         {{- end }}
         {{- toYaml $securityContext | nindent 8 }}
+      {{- if .Values.frontend.serviceAccountName }}
+      serviceAccountName: {{ .Values.api.serviceAccountName }}
+      {{- end }}
 {{- with .Values.frontend.extraInitContainers }}
       initContainers:
 {{- toYaml . | nindent 6 }}

--- a/charts/flagsmith/templates/deployment-pgbouncer.yaml
+++ b/charts/flagsmith/templates/deployment-pgbouncer.yaml
@@ -65,6 +65,9 @@ spec:
         {{- $securityContext = $securityContext | merge (omit .Values.pgbouncer.defaultPodSecurityContext "enabled") }}
         {{- end }}
         {{- toYaml $securityContext | nindent 8 }}
+      {{- if .Values.pgbouncer.serviceAccountName }}
+      serviceAccountName: {{ .Values.api.serviceAccountName }}
+      {{- end }}
 {{- with .Values.pgbouncer.extraInitContainers }}
       initContainers:
 {{- toYaml . | nindent 6 }}

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -68,6 +68,9 @@ spec:
         {{- $securityContext = $securityContext | merge (omit .Values.taskProcessor.defaultPodSecurityContext "enabled") }}
         {{- end }}
         {{- toYaml $securityContext | nindent 8 }}
+      {{- if .Values.taskProcessor.serviceAccountName }}
+      serviceAccountName: {{ .Values.api.serviceAccountName }}
+      {{- end }}
 {{- with .Values.taskProcessor.extraInitContainers }}
       initContainers:
 {{- toYaml . | nindent 6 }}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes

This allows to set a specific service account for every deployed pod.

## How did you test this code?

Added the new key to values.yaml and observed the resulting k8s deployments.