### PR TITLE
fix: Incorrect `serviceAccountName` values

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.46.0
+version: 0.47.0
 appVersion: 2.120.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/deployment-frontend.yaml
+++ b/charts/flagsmith/templates/deployment-frontend.yaml
@@ -65,7 +65,7 @@ spec:
         {{- end }}
         {{- toYaml $securityContext | nindent 8 }}
       {{- if .Values.frontend.serviceAccountName }}
-      serviceAccountName: {{ .Values.api.serviceAccountName }}
+      serviceAccountName: {{ .Values.frontend.serviceAccountName }}
       {{- end }}
 {{- with .Values.frontend.extraInitContainers }}
       initContainers:

--- a/charts/flagsmith/templates/deployment-pgbouncer.yaml
+++ b/charts/flagsmith/templates/deployment-pgbouncer.yaml
@@ -66,7 +66,7 @@ spec:
         {{- end }}
         {{- toYaml $securityContext | nindent 8 }}
       {{- if .Values.pgbouncer.serviceAccountName }}
-      serviceAccountName: {{ .Values.api.serviceAccountName }}
+      serviceAccountName: {{ .Values.pgbouncer.serviceAccountName }}
       {{- end }}
 {{- with .Values.pgbouncer.extraInitContainers }}
       initContainers:

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -69,7 +69,7 @@ spec:
         {{- end }}
         {{- toYaml $securityContext | nindent 8 }}
       {{- if .Values.taskProcessor.serviceAccountName }}
-      serviceAccountName: {{ .Values.api.serviceAccountName }}
+      serviceAccountName: {{ .Values.taskProcessor.serviceAccountName }}
       {{- end }}
 {{- with .Values.taskProcessor.extraInitContainers }}
       initContainers:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes

This fixes incorrect behaviour when Helm used `api`'s `serviceAccountName` for other deployments.

## How did you test this code?

Deployed to local k8s.