### PR TITLE
feat: `serviceAccountName` for migrate job, expose `migrate-and-serve` entrypoint

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.47.0
+version: 0.48.0
 appVersion: 2.120.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -120,8 +120,11 @@ spec:
       - name: {{ .Chart.Name }}-api
         image: {{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default (printf "%s" .Chart.AppVersion) }}
         imagePullPolicy: {{ .Values.api.image.imagePullPolicy }}
-        # command: ["sleep", "3600"]
+        {{- if .Values.api.enableMigrateAndServe }}
+        args: ["migrate-and-serve"]
+        {{- else }}
         args: ["serve"]
+        {{- end }}
         ports:
         - containerPort: {{ .Values.service.api.port }}
         env: {{ include (print $.Template.BasePath "/_api_environment.yaml") . | nindent 8 }}

--- a/charts/flagsmith/templates/jobs-migrate-db.yaml
+++ b/charts/flagsmith/templates/jobs-migrate-db.yaml
@@ -52,6 +52,9 @@ spec:
         {{- $securityContext = $securityContext | merge (omit .Values.jobs.migrateDb.defaultPodSecurityContext "enabled") }}
         {{- end }}
         {{- toYaml $securityContext | nindent 8 }}
+      {{- if .Values.jobs.migrateDb.serviceAccountName }}
+      serviceAccountName: {{ .Values.jobs.migrateDb.serviceAccountName }}
+      {{- end }}
       {{- if .Values.jobs.migrateDb.shareProcessNamespace }}
       shareProcessNamespace: true
       {{- end }}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes

This adds the following:
- Exposes the `migrate-and-serve` entrypoint for those who wish to migrate in the entrypoint without resorting to a job or an init container.
- Exposes the `serviceAccoutName` spec for the migration job.

## How did you test this code?

Observed the templated values locally.