### PR TITLE
fix: Incorrect env indentation for bootstrap

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.51.0
+version: 0.52.0
 appVersion: 2.128.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -88,18 +88,18 @@ spec:
         command: ["/bin/sh", "-c"]
         args: ["python manage.py waitfordb && python manage.py bootstrap"]
         env: {{ include (print $.Template.BasePath "/_api_environment.yaml") . | nindent 8 }}
-          {{- if .Values.api.bootstrap.adminEmail }}
-          - name: ADMIN_EMAIL
-            value: {{ .Values.api.bootstrap.adminEmail }}
-          {{- end }}
-          {{- if .Values.api.bootstrap.organisationName }}
-          - name: ORGANISATION_NAME
-            value: {{ .Values.api.bootstrap.organisationName }}
-          {{- end }}
-          {{- if .Values.api.bootstrap.projectName }}
-          - name: PROJECT_NAME
-            value: {{ .Values.api.bootstrap.projectName }}
-          {{- end }}
+        {{- if .Values.api.bootstrap.adminEmail }}
+        - name: ADMIN_EMAIL
+          value: {{ .Values.api.bootstrap.adminEmail }}
+        {{- end }}
+        {{- if .Values.api.bootstrap.organisationName }}
+        - name: ORGANISATION_NAME
+          value: {{ .Values.api.bootstrap.organisationName }}
+        {{- end }}
+        {{- if .Values.api.bootstrap.projectName }}
+        - name: PROJECT_NAME
+          value: {{ .Values.api.bootstrap.projectName }}
+        {{- end }}
 {{- end }}
 {{- if .Values.api.influxdbSetup.enabled }}
       - name: influxdb-setup


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes

Fixed incorrect env indentation when bootstrap is enabled and one of `adminEmail`, `organisationName`, `projectName` is set.

## How did you test this code?

Tested manually with `helm template .` with values above defined. 
