### PR TITLE
feat: add extraObjects

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.51.0
+version: 0.51.1
 appVersion: 2.128.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/extra-objects.yaml
+++ b/charts/flagsmith/templates/extra-objects.yaml
@@ -1,0 +1,8 @@
+{{ range .Values.extraObjects }}
+---
+{{ if typeIs "string" . }}
+    {{- tpl . $ }}
+{{- else }}
+    {{- tpl (toYaml .) $ }}
+{{- end }}
+{{ end }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -380,3 +380,18 @@ _destructiveTests:
     resources:
       requests:
         memory: 1Gi
+
+# -- Array of extra K8s manifests to deploy
+## Note: Supports use of custom Helm templates
+## Example: Deploying a CloudnativePG Postgres cluster for use with Flagmsith:
+extraObjects: []
+# - |
+#   apiVersion: postgresql.cnpg.io/v1
+#   kind: Cluster
+#   metadata:
+#     name: flagsmith
+#     namespace: {{ .Release.Namespace }}
+#   spec:
+#     instances: 3
+#     storage:
+#       size: 10Gi


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes

I'd like to be able to deploy other resources not included in the chart; Gateway HTTPRoutes, CloudnativePG Clusters etc.
I've added the same technique ArgoCD uses for this:

[ArgoCD](https://github.com/argoproj/argo-helm/blob/8b02b6d9b828902ba0d9ae1e6ddb4f060a5975ca/charts/argo-cd/values.yaml#L564-L591) - https://github.com/argoproj/argo-helm/blob/8b02b6d9b828902ba0d9ae1e6ddb4f060a5975ca/charts/argo-cd/templates/extra-manifests.yaml

Figured it was better than asking for every option under the sun for you to implement so I could use GatewayAPI HTTP Routes with Istio instead of Ingress objects.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Added an empty configMap to the helm values and deployed it and it was included in the helm release.
