### PR TITLE
feat: Allow including extra `spec` keys for deployments

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.59.1
-appVersion: 2.142.0
+version: 0.60.0
+appVersion: 2.153.0
 dependencies:
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -164,3 +164,6 @@ spec:
 {{- with .Values.api.extraVolumes }}
 {{- toYaml . | nindent 6 }}
 {{- end }}
+{{- with .Values.api.extraSpec }}
+{{- toYaml . | nindent 2 }}
+{{- end }}

--- a/charts/flagsmith/templates/deployment-frontend.yaml
+++ b/charts/flagsmith/templates/deployment-frontend.yaml
@@ -107,4 +107,7 @@ spec:
 {{- with .Values.frontend.extraVolumes }}
 {{- toYaml . | nindent 6 }}
 {{- end }}
+{{- with .Values.frontend.extraSpec }}
+{{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -115,4 +115,7 @@ spec:
 {{- with .Values.taskProcessor.extraVolumes }}
 {{- toYaml . | nindent 6 }}
 {{- end }}
+{{- with .Values.taskProcessor.extraSpec }}
+{{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -382,3 +382,18 @@ _destructiveTests:
     resources:
       requests:
         memory: 1Gi
+
+# -- Array of extra K8s manifests to deploy
+## Note: Supports use of custom Helm templates
+## Example: Deploying a CloudnativePG Postgres cluster for use with Flagmsith:
+extraObjects: []
+# - |
+#   apiVersion: postgresql.cnpg.io/v1
+#   kind: Cluster
+#   metadata:
+#     name: flagsmith
+#     namespace: {{ .Release.Namespace }}
+#   spec:
+#     instances: 3
+#     storage:
+#       size: 10Gi

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -192,6 +192,7 @@ taskProcessor:
   extraContainers: []
   extraEnv: {}
   extraVolumes: []
+  extraSpec: {} # Will be added to `spec` for `flagsmith-task-processor` deployment. 
 
 devPostgresql:
   enabled: true

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -87,7 +87,7 @@ api:
     adminEmail: null
     organisationName: null
     projectName: null
-  extraSpec: {} # Will be added to `spec` for `flagsmith-api` deployment.
+    extraSpec: {} # Will be added to `spec` for `flagsmith-api` deployment. 
 
 frontend:
   # Set this to `false` to switch off the frontend (deployment,
@@ -137,7 +137,7 @@ frontend:
   extraInitContainers: []
   extraContainers: []
   extraVolumes: []
-  extraSpec: {} # Will be added to `spec` for `flagsmith-frontend`` deployment.
+  extraSpec: {} # Will be added to `spec` for `flagsmith-frontend` deployment. 
 
 # See https://docs.flagsmith.com/deployment/task-processor
 taskProcessor:
@@ -263,14 +263,14 @@ pgbouncer:
 influxdb2:
   enabled: true
   adminUser:
-    organization: "influxdata"
-    bucket: "default"
-    user: "admin"
-    retention_policy: "0s"
+    organization: 'influxdata'
+    bucket: 'default'
+    user: 'admin'
+    retention_policy: '0s'
     ## Leave empty to generate a random password and token.
     ## Or fill any of these values to use fixed values.
-    password: ""
-    token: ""
+    password: ''
+    token: ''
     ## The password and token are obtained from an existing secret. The expected
     ## keys are `admin-password` and `admin-token`.
     ## If set, the password and token values above are ignored.
@@ -382,18 +382,3 @@ _destructiveTests:
     resources:
       requests:
         memory: 1Gi
-
-# -- Array of extra K8s manifests to deploy
-## Note: Supports use of custom Helm templates
-## Example: Deploying a CloudnativePG Postgres cluster for use with Flagmsith:
-extraObjects: []
-# - |
-#   apiVersion: postgresql.cnpg.io/v1
-#   kind: Cluster
-#   metadata:
-#     name: flagsmith
-#     namespace: {{ .Release.Namespace }}
-#   spec:
-#     instances: 3
-#     storage:
-#       size: 10Gi

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -87,6 +87,7 @@ api:
     adminEmail: null
     organisationName: null
     projectName: null
+  extraSpec: {} # Will be added to `spec` for `flagsmith-api` deployment.
 
 frontend:
   # Set this to `false` to switch off the frontend (deployment,
@@ -136,6 +137,7 @@ frontend:
   extraInitContainers: []
   extraContainers: []
   extraVolumes: []
+  extraSpec: {} # Will be added to `spec` for `flagsmith-frontend`` deployment.
 
 # See https://docs.flagsmith.com/deployment/task-processor
 taskProcessor:
@@ -261,14 +263,14 @@ pgbouncer:
 influxdb2:
   enabled: true
   adminUser:
-    organization: 'influxdata'
-    bucket: 'default'
-    user: 'admin'
-    retention_policy: '0s'
+    organization: "influxdata"
+    bucket: "default"
+    user: "admin"
+    retention_policy: "0s"
     ## Leave empty to generate a random password and token.
     ## Or fill any of these values to use fixed values.
-    password: ''
-    token: ''
+    password: ""
+    token: ""
     ## The password and token are obtained from an existing secret. The expected
     ## keys are `admin-password` and `admin-token`.
     ## If set, the password and token values above are ignored.


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes

Closes #291.

This allows to add arbitrary keys to both of the deployment's specs.

## How did you test this code?

Added corresponding keys to `values.yaml` and observed the resulting template.