### PR TITLE
change hostname in helpers.tpl and api_enviroment

### DIFF
--- a/charts/flagsmith/templates/_api_environment.yaml
+++ b/charts/flagsmith/templates/_api_environment.yaml
@@ -20,7 +20,7 @@
       {{- end }}
 {{- if .Values.influxdb2.enabled }}
 - name: INFLUXDB_URL
-  value: http://{{- template "flagsmith.influxdb.hostname" . -}}:80
+  value: http://{{- template "flagsmith.influxdb.hostname.kubemain" . -}}:80
 - name: INFLUXDB_BUCKET
   value: {{ .Values.influxdb2.adminUser.bucket }}
 - name: INFLUXDB_ORG

--- a/charts/flagsmith/templates/_helpers.tpl
+++ b/charts/flagsmith/templates/_helpers.tpl
@@ -225,6 +225,15 @@ Influxdb hostname
 {{- end -}}
 
 {{/*
+Influxdb hostname kube-main
+*/}}
+{{- define "flagsmith.influxdb.hostname.kubemain" -}}
+{{ template "flagsmith.influxdb.fullname" . }}.{{ .Release.Namespace }}.svc.kube-main.local
+{{- end -}}
+
+
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}


### PR DESCRIPTION

Good afternoon. 
I encountered a problem in the form of generating a value for the INFLUXDB_URL variable
This refers to influxdb2 which is included in the helm chart itself. We don't use external ones. 

We do not have a standard cluster name. 
The problem was that flagsmith-api could not connect to influxdb2
http://flagsmith-new-influxdb2.microservices.svc.kube-main.local:80 we needed this
DNS name
Unfortunately, it was not possible to override the INFLUXDB_URL values for flagsmith-api

Is it possible to add this functionality? 

PR shows the changes I made

This helm chart was tested by deployment to the k8s cluster

chart version 0.42.0