### PR TITLE
fix: Add missing SSE ingress

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.64.0
+version: 0.65.0
 appVersion: 2.159.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/ingress-sse.yaml
+++ b/charts/flagsmith/templates/ingress-sse.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.ingress.sse.enabled -}}
+{{- $fullName := include "flagsmith.fullname" . -}}
+{{- $svcPort := .Values.service.sse.port -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-sse
+  labels:
+    {{- include "flagsmith.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sse
+  {{- $annotations := include "flagsmith.annotations" ( dict "customAnnotations" .Values.ingress.sse.annotations "commonValues" .Values.common ) }}
+  {{- with $annotations }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+spec:
+{{- with .Values.ingress.sse.ingressClassName }}
+  ingressClassName: {{ . }}
+{{- end }}
+  {{- if .Values.ingress.sse.tls }}
+  tls:
+    {{- range .Values.ingress.sse.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.sse.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName}}-sse
+                port: 
+                  number: {{ $svcPort }}
+            {{- else }}
+            backend:
+              serviceName: {{ $fullName }}-sse
+              servicePort: {{ $svcPort }}
+            {{- end }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -315,6 +315,7 @@ sse:
   # extraEnv:
   #   REDIS_HOST: redis.example.com
   #   REDIS_PORT: 6379
+  #   USE_CLUSTER_MODE: true # - set this if connecting to a Redis cluster, not a single node
   # extraEnvFromSecret:
   #   REDIS_PASSWORD:
   #    secretName: my_redis_secrets


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes

`ingress.sse` currently does nothing. This change adds a missing file to actually handle SSE ingress.

## How did you test this code?

Manually using this values file:

<details>

```yaml
common:
  # Labels to add to all the resources deployed by this chart
  labels: {}
  # Annotations to add to all the resources deployed by this chart
  annotations: {}

api:
  image:
    repository: flagsmith/flagsmith-private-cloud
    tag: latest
    imagePullPolicy: IfNotPresent
    imagePullSecrets: []
  # Note that if setting this to false, need to set
  # api.image.repository to flagsmith/flagsmith (or some other
  # repository hosting the image with combined frontend and backend)
  # and that the image tag exists (for flagsmith/flagsmith, >=2.10.0)
  #
  # Also, note that the ingress and service for the frontend remain
  # (unless explicitly switched off), but both are handled by the api
  # deployment's pods.
  separateApiAndFrontend: true
  replicacount: 1
  deploymentStrategy: null
  podAnnotations: {}
  resources: {}
  # limits:
  #   cpu: 500m
  #   memory: 500Mi
  # requests:
  #   cpu: 300m
  #   memory: 300Mi
  podLabels: {}
  extraEnv: {}
  # extraEnvFromSecret:
  #   NAME:
  #    secretName: mysecret
  #    secretKey: mykey
  extraEnvFromSecret: {}
  # See https://docs.flagsmith.com/deployment/locally-api#creating-a-secret-key
  secretKey: null
  secretKeyFromExistingSecret:
    enabled: false
    name: null
    key: null
  nodeSelector: {}
  tolerations: []
  affinity: {}
  podSecurityContext: {}
  defaultPodSecurityContext:
    enabled: true
    # runAsNonRoot: true  # TODO: enable this, conditional on tag semver
    # runAsUser: 1000
    # runAsGroup: 1000
  livenessProbe:
    path: /health
    failureThreshold: 5
    initialDelaySeconds: 5
    periodSeconds: 10
    successThreshold: 1
    timeoutSeconds: 2
  readinessProbe:
    path: /health
    failureThreshold: 10
    initialDelaySeconds: 1
    periodSeconds: 10
    successThreshold: 1
    timeoutSeconds: 2
  statsd:
    enabled: false
    host: null
    hostFromNodeIp: false
    port: 8125
    prefix: flagsmith.api
  influxdbSetup:
    enabled: false
  extraInitContainers: []
  extraContainers: []
  extraVolumes:
    - name: exports
      emptyDir: {}
  volumeMounts:
    - name: exports
      mountPath: /exports
  logging:
    format: generic # options are generic or json.
  enableMigrateDbInitContainer: true
  bootstrap:
    # Set to `true` to create initial superuser, organisation, and project.
    # If `adminEmail`, `organisationName` or `projectName` not set, defaults are used.
    # Bootstrapping does nothing if app database is not empty.
    enabled: false
    adminEmail: null
    organisationName: null
    projectName: null
    extraSpec: {} # Will be added to `spec` for `flagsmith-api` deployment. 

frontend:
  # Set this to `false` to switch off the frontend (deployment,
  # service and ingress). Set api.separateApiAndFrontend to false to
  # switch off the deployment but retain the service and ingress
  # pointing at the single Docker image that serves both.
  enabled: true
  image:
    repository: flagsmith.docker.scarf.sh/flagsmith/flagsmith-frontend
    tag: null # defaults to .Chart.AppVersion
    imagePullPolicy: IfNotPresent
    imagePullSecrets: []
  replicacount: 1
  deploymentStrategy: null
  resources: {}
  # limits:
  #   cpu: 500m
  #   memory: 500Mi
  # requests:
  #   cpu: 300m
  #   memory: 300Mi
  apiProxy:
    enabled: true
  extraEnv: {}
  extraEnvFromSecret: {}
  nodeSelector: {}
  tolerations: []
  affinity: {}
  podSecurityContext: {}
  defaultPodSecurityContext:
    enabled: true
    # runAsNonRoot: true  # TODO: enable this, conditional on tag semver
    # runAsUser: 1000
    # runAsGroup: 1000
  livenessProbe:
    failureThreshold: 20
    initialDelaySeconds: 20
    periodSeconds: 10
    successThreshold: 1
    timeoutSeconds: 10
  readinessProbe:
    failureThreshold: 20
    initialDelaySeconds: 20
    periodSeconds: 10
    successThreshold: 1
    timeoutSeconds: 10
  extraInitContainers: []
  extraContainers: []
  extraVolumes: []
  extraSpec: {} # Will be added to `spec` for `flagsmith-frontend` deployment. 

# See https://docs.flagsmith.com/deployment/task-processor
taskProcessor:
  image:
    # all values here default to those in .Values.api.image if not configured
    # this is to simplify the logic for those using flagsmith-api image
    # and to maintain backwards compatibility.
    repository: flagsmith/flagsmith-private-cloud
    tag: latest
    imagePullPolicy: IfNotPresent
    imagePullSecrets: []

  enabled: true
  replicacount: 1
  sleepIntervalMs: null
  numThreads: null
  gracePeriodMs: null
  queuePopSize: null

  livenessProbe:
    failureThreshold: 5
    initialDelaySeconds: 5
    periodSeconds: 10
    successThreshold: 1
    timeoutSeconds: 2
  readinessProbe:
    failureThreshold: 10
    initialDelaySeconds: 1
    periodSeconds: 10
    successThreshold: 1
    timeoutSeconds: 2

  podAnnotations: {}
  resources: {}
  # limits:
  #   cpu: 500m
  #   memory: 500Mi
  # requests:
  #   cpu: 300m
  #   memory: 300Mi
  podLabels: {}
  nodeSelector: {}
  tolerations: []
  affinity: {}
  podSecurityContext: {}
  defaultPodSecurityContext:
    enabled: true
    # runAsNonRoot: true  # TODO: enable this, conditional on tag semver
    # runAsUser: 1000
    # runAsGroup: 1000
  extraInitContainers: []
  extraContainers: []
  extraEnv: {}
  extraVolumes: []
  extraSpec: {} # Will be added to `spec` for `flagsmith-task-processor` deployment. 

devPostgresql:
  enabled: true
  serviceAccount:
    create: true
  nameOverride: dev-postgresql
  auth:
    postgresPassword: flagsmith
    database: flagsmith

databaseExternal:
  enabled: false
  url: null
  type: postgres
  host: null
  port: 5432
  database: null
  username: null
  password: null
  urlFromExistingSecret:
    enabled: false
    name: null
    key: null

pgbouncer:
  enabled: false
  image:
    repository: bitnami/pgbouncer
    tag: 1.16.0
    imagePullPolicy: IfNotPresent
    imagePullSecrets: []
  replicaCount: 1
  deploymentStrategy: null
  podAnnotations: {}
  resources: {}
  podLabels: {}
  extraEnv: {}
  nodeSelector: {}
  tolerations: []
  affinity: {}
  podSecurityContext: {}
  defaultPodSecurityContext:
    enabled: true
    # runAsNonRoot: true
  securityContext: {}
  defaultSecurityContext:
    enabled: true
    allowPrivilegeEscalation: false
    capabilities:
      drop:
        - all

  livenessProbe:
    failureThreshold: 5
    initialDelaySeconds: 5
    periodSeconds: 10
    successThreshold: 1
    timeoutSeconds: 2
  readinessProbe:
    failureThreshold: 10
    initialDelaySeconds: 1
    periodSeconds: 10
    successThreshold: 1
    timeoutSeconds: 2
  extraInitContainers: []
  extraContainers: []
  extraVolumes: []

influxdb2:
  enabled: false
  adminUser:
    organization: 'influxdata'
    bucket: 'default'
    user: 'admin'
    retention_policy: '0s'
    ## Leave empty to generate a random password and token.
    ## Or fill any of these values to use fixed values.
    password: ''
    token: ''
    ## The password and token are obtained from an existing secret. The expected
    ## keys are `admin-password` and `admin-token`.
    ## If set, the password and token values above are ignored.
    existingSecret: null
  persistence:
    enabled: false
    # storageClass: "-"
    # accessMode: ReadWriteOnce
    # size: 50Gi
  resources: {}
  nodeSelector: {}
  tolerations: []
  affinity: {}

influxdbExternal:
  enabled: false
  url: null
  bucket: null
  organization: null
  token: null
  tokenFromExistingSecret:
    enabled: false
    name: null
    key: null

# This is included primarily for easy testing of statsd integration from the application.
graphite:
  enabled: false
  nameOverride: flagsmith-graphite
  autoSetStatsdHostEnvVar: true

sse:
  enabled: true
  image:
    repository: flagsmith/sse
    tag: 3.4.0
    imagePullPolicy: IfNotPresent
    imagePullSecrets: []
  # See all supported environment variables here:
  # https://docs.flagsmith.com/deployment/hosting/real-time/deployment#sse-service
  extraEnv:
    REDIS_HOST: redis
    REDIS_PORT: 6379
  # extraEnvFromSecret:
  #   REDIS_PASSWORD:
  #    secretName: my_redis_secrets
  #    secretKey: my_redis_password
  replicaCount: 1
  deploymentStrategy: null
  podAnnotations: {}
  resources: {}
  # limits:
  #   cpu: 500m
  #   memory: 500Mi
  # requests:
  #   cpu: 300m
  #   memory: 300Mi
  podLabels: {}
  nodeSelector: {}
  tolerations: []
  affinity: {}
  podSecurityContext: {}
  defaultPodSecurityContext:
    enabled: true
    # runAsNonRoot: true  # TODO: enable this, conditional on tag semver
    # runAsUser: 1000
    # runAsGroup: 1000
  livenessProbe:
    path: /health
    failureThreshold: 5
    initialDelaySeconds: 5
    periodSeconds: 10
    successThreshold: 1
    timeoutSeconds: 2
  readinessProbe:
    path: /health
    failureThreshold: 10
    initialDelaySeconds: 1
    periodSeconds: 10
    successThreshold: 1
    timeoutSeconds: 2
  shareProcessNamespace: false
  serviceAccountName: null
  extraInitContainers: []
  extraContainers: []
  extraVolumes: []

service:
  api:
    type: ClusterIP
    port: 8000
    annotations: {}
  frontend:
    type: ClusterIP
    port: 8080
    annotations: {}
  sse:
    type: ClusterIP
    port: 8000
    annotations: {}

ingress:
  frontend:
    enabled: false
    annotations: {}
    ingressClassName: null
    # kubernetes.io/ingress.class: nginx
    # kubernetes.io/tls-acme: "true"
    hosts:
      - chart-example.local
    tls: []
    #  - secretName: chart-example-tls
    #    hosts:
    #      - chart-example.local
  api:
    enabled: true
    annotations: {}
    ingressClassName: null
    # kubernetes.io/ingress.class: nginx
    # kubernetes.io/tls-acme: "true"
    hosts:
      - host: chart-example.local
        paths:
          - '/'
    tls: []
    #  - secretName: chart-example-tls
    #    hosts:
    #      - chart-example.local
  sse:
    enabled: true
    annotations: {}
    ingressClassName: null
    # kubernetes.io/ingress.class: nginx
    # kubernetes.io/tls-acme: "true"
    hosts:
      - host: chart-example.local
        paths:
          - /
    tls: []
    #  - secretName: chart-example-tls
    #    hosts:
    #      - chart-example.local

jobs:
  migrateDb:
    enabled: false
    ttlSecondsAfterFinished: 3600
    restartPolicy: OnFailure
    defaultPodSecurityContext:
      enabled: true
      # runAsNonRoot: true
    extraContainers: []
    extraVolumes: []
    command: []
    args: []

# These tests just make non-destructive requests to the services in
# the cluster. Enabling this and running helm test is safe.
tests:
  # A test is enabled if both this and the specific test is enabled
  enabled: false
  api:
    enabled: true
    maxTime: 10
    printResponseBody: false
  frontend:
    enabled: true
    maxTime: 10
    printResponseBody: false

# These are used for integration testing the chart and the
# application. Enabling this will mean that data in a release is
# destroyed or corrupted if the tests are run.
_destructiveTests:
  # A test is enabled if both this and the specific test is enabled
  enabled: false
  testToken: test-e2e-token
  e2e:
    enabled: true
    image:
      repository: flagsmith/flagsmith-e2e-tests
      tag: null
      imagePullPolicy: IfNotPresent
    resources:
      requests:
        memory: 1Gi

# -- Array of extra K8s manifests to deploy
## Note: Supports use of custom Helm templates
## Example: Deploying a CloudnativePG Postgres cluster for use with Flagmsith:
extraObjects: []
# - |
#   apiVersion: postgresql.cnpg.io/v1
#   kind: Cluster
#   metadata:
#     name: flagsmith
#     namespace: {{ .Release.Namespace }}
#   spec:
#     instances: 3
#     storage:
#       size: 10Gi
```

</details>

and verifying the SSE ingress is created:

```
% kubectl describe ingress
Name:             flagsmith-sse-k8s-api
Labels:           app.kubernetes.io/component=api
                  app.kubernetes.io/instance=flagsmith-sse-k8s
                  app.kubernetes.io/managed-by=Helm
                  app.kubernetes.io/name=flagsmith
                  app.kubernetes.io/version=2.159.0
                  helm.sh/chart=flagsmith-0.65.0
Namespace:        default
Address:          
Ingress Class:    <none>
Default backend:  <default>
Rules:
  Host                 Path  Backends
  ----                 ----  --------
  chart-example.local  
                       /   flagsmith-sse-k8s-api:8000 (192.168.194.98:8000)
Annotations:           meta.helm.sh/release-name: flagsmith-sse-k8s
                       meta.helm.sh/release-namespace: default
Events:                <none>


Name:             flagsmith-sse-k8s-sse
Labels:           app.kubernetes.io/component=sse
                  app.kubernetes.io/instance=flagsmith-sse-k8s
                  app.kubernetes.io/managed-by=Helm
                  app.kubernetes.io/name=flagsmith
                  app.kubernetes.io/version=2.159.0
                  helm.sh/chart=flagsmith-0.65.0
Namespace:        default
Address:          
Ingress Class:    <none>
Default backend:  <default>
Rules:
  Host                 Path  Backends
  ----                 ----  --------
  chart-example.local  
                       /   flagsmith-sse-k8s-sse:8000 ()
Annotations:           meta.helm.sh/release-name: flagsmith-sse-k8s
                       meta.helm.sh/release-namespace: default
Events:                <none>
```
