### PR TITLE
fix: Enable ENABLE_ADMIN_ACCESS_USER_PASS by default

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.67.0
+version: 0.67.1
 appVersion: 2.159.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -30,7 +30,11 @@ api:
   #   cpu: 300m
   #   memory: 300Mi
   podLabels: {}
-  extraEnv: {}
+  # https://docs.flagsmith.com/deployment/hosting/locally-api#environment-variables
+  extraEnv:
+    # Allows authenticating with a local password to Django Admin
+    # See https://docs.flagsmith.com/deployment/configuration/django-admin
+    ENABLE_ADMIN_ACCESS_USER_PASS: true
   # extraEnvFromSecret:
   #   NAME:
   #    secretName: mysecret


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes

Enables `ENABLE_ADMIN_ACCESS_USER_PASS` by default, similar to our default Docker Compose setup: https://github.com/Flagsmith/flagsmith/blob/3557e1480ae8cbc7f4e60492fba87b4328a39fd1/docker-compose.yml#L38

I chose to add this to `extraEnv` instead of a named value because ideally it should not be needed in the future, which avoids adding to the public API of our Helm values.

## How did you test this code?

Tested manually by deploying and logging in to Django Admin.
