### PR TITLE
feat: Add templating functionality to extraContainers

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.67.1
+version: 0.68.0
 appVersion: 2.159.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -153,7 +153,11 @@ spec:
         resources:
 {{ toYaml .Values.api.resources | indent 10 }}
 {{- with .Values.api.extraContainers }}
-{{- toYaml . | nindent 6 }}
+{{ if typeIs "string" . }}
+    {{- tpl . $ | nindent 6 }}
+{{- else }}
+    {{- tpl (toYaml .) $ | nindent 6 }}
+{{- end }}
 {{- end }}
       volumes:
 {{- if .Values.api.influxdbSetup.enabled }}

--- a/charts/flagsmith/templates/deployment-frontend.yaml
+++ b/charts/flagsmith/templates/deployment-frontend.yaml
@@ -101,7 +101,11 @@ spec:
         resources:
 {{ toYaml .Values.frontend.resources | indent 10 }}
 {{- with .Values.frontend.extraContainers }}
-{{- toYaml . | nindent 6 }}
+{{ if typeIs "string" . }}
+    {{- tpl . $ | nindent 6 }}
+{{- else }}
+    {{- tpl (toYaml .) $ | nindent 6 }}
+{{- end }}
 {{- end }}
       volumes:
 {{- with .Values.frontend.extraVolumes }}

--- a/charts/flagsmith/templates/deployment-pgbouncer.yaml
+++ b/charts/flagsmith/templates/deployment-pgbouncer.yaml
@@ -141,7 +141,11 @@ spec:
         resources:
 {{ toYaml .Values.pgbouncer.resources | indent 10 }}
 {{- with .Values.pgbouncer.extraContainers }}
-{{- toYaml . | nindent 6 }}
+{{ if typeIs "string" . }}
+    {{- tpl . $ | nindent 6 }}
+{{- else }}
+    {{- tpl (toYaml .) $ | nindent 6 }}
+{{- end }}
 {{- end }}
       volumes:
 {{- with .Values.pgbouncer.extraVolumes }}

--- a/charts/flagsmith/templates/deployment-sse.yaml
+++ b/charts/flagsmith/templates/deployment-sse.yaml
@@ -100,7 +100,11 @@ spec:
         resources:
 {{ toYaml .Values.sse.resources | indent 10 }}
 {{- with .Values.sse.extraContainers }}
-{{- toYaml . | nindent 6 }}
+{{ if typeIs "string" . }}
+    {{- tpl . $ | nindent 6 }}
+{{- else }}
+    {{- tpl (toYaml .) $ | nindent 6 }}
+{{- end }}
 {{- end }}
       volumes:
 {{- with .Values.sse.extraVolumes }}

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -109,7 +109,11 @@ spec:
         resources:
 {{ toYaml .Values.taskProcessor.resources | indent 10 }}
 {{- with .Values.taskProcessor.extraContainers }}
-{{- toYaml . | nindent 6 }}
+{{ if typeIs "string" . }}
+    {{- tpl . $ | nindent 6 }}
+{{- else }}
+    {{- tpl (toYaml .) $ | nindent 6 }}
+{{- end }}
 {{- end }}
       volumes:
 {{- with .Values.taskProcessor.extraVolumes }}

--- a/charts/flagsmith/templates/jobs-migrate-analytics-data.yaml
+++ b/charts/flagsmith/templates/jobs-migrate-analytics-data.yaml
@@ -30,7 +30,11 @@ spec:
         {{- end }}
         env: {{ include (print $.Template.BasePath "/_api_environment.yaml") . | nindent 8 }}
 {{- with .Values.jobs.migrateDb.extraContainers }}
-{{- toYaml . | nindent 6 }}
+{{ if typeIs "string" . }}
+    {{- tpl . $ | nindent 6 }}
+{{- else }}
+    {{- tpl (toYaml .) $ | nindent 6 }}
+{{- end }}
 {{- end }}
       volumes:
 {{- with .Values.jobs.migrateDb.extraVolumes }}

--- a/charts/flagsmith/templates/jobs-migrate-db.yaml
+++ b/charts/flagsmith/templates/jobs-migrate-db.yaml
@@ -72,7 +72,11 @@ spec:
         {{- end }}
         env: {{ include (print $.Template.BasePath "/_api_environment.yaml") . | nindent 8 }}
 {{- with .Values.jobs.migrateDb.extraContainers }}
-{{- toYaml . | nindent 6 }}
+{{ if typeIs "string" . }}
+    {{- tpl . $ | nindent 6 }}
+{{- else }}
+    {{- tpl (toYaml .) $ | nindent 6 }}
+{{- end }}
 {{- end }}
       volumes:
 {{- with .Values.jobs.migrateDb.extraVolumes }}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes

Allow templating in `extraContainers`, closing #304.

Adjust template logic for `extraContainers` to support both string and non-string types. Strings are evaluated as templates, similar to `extraObjects`.

## How did you test this code?

Manually.

```bash
$ helm template flagsmith --dry-run --debug charts/flagsmith/ -f flagsmith.values.yaml
```

```yaml
 # flagsmith.values.yaml

 # ...
 extraContainers: |
    - name: cloud-sql-proxy
      image: {{ $.Values.sqlProxySidecar.image.repository }}:{{ $.Values.sqlProxySidecar.image.tag }}
      imagePullPolicy: IfNotPresent
      command:
        # Start Cloud SQL Proxy
        - /cloud-sql-proxy

        # Add structured logs as JSON
        - --structured-logs
 # ...

```