### PR TITLE
ci: Use manual releases, check version bump only when releasing

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.4.1
+          version: v3.5.4
 
       - uses: actions/setup-python@v5
         with:
@@ -42,7 +42,7 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --config ct.yaml --lint-conf lintconf.yaml
+        run: ct lint --config ct.yaml --lint-conf lintconf.yaml --check-version-increment=false
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,7 @@
 name: Release Charts
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   release:
@@ -24,6 +22,11 @@ jobs:
         with:
           version: v3.5.4
 
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+        with:
+          version: v3.3.0
+
       - name: Add chart repo dependencies
         # Note: this repos should match whith the repos set in ct.yaml
         # See https://github.com/Flagsmith/flagsmith-charts/issues/105
@@ -32,6 +35,9 @@ jobs:
           helm repo add influxdb2 https://helm.influxdata.com/
           helm repo add kiwigrid https://kiwigrid.github.io
           helm repo add bitnami https://charts.bitnami.com/bitnami
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config ct.yaml --lint-conf lintconf.yaml
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,11 +22,6 @@ jobs:
         with:
           version: v3.5.4
 
-      - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.0.1
-        with:
-          version: v3.3.0
-
       - name: Add chart repo dependencies
         # Note: this repos should match whith the repos set in ct.yaml
         # See https://github.com/Flagsmith/flagsmith-charts/issues/105
@@ -35,6 +30,11 @@ jobs:
           helm repo add influxdb2 https://helm.influxdata.com/
           helm repo add kiwigrid https://kiwigrid.github.io
           helm repo add bitnami https://charts.bitnami.com/bitnami
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+        with:
+          version: v3.3.0
 
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml --lint-conf lintconf.yaml


### PR DESCRIPTION
This is not yet tested.

Makes releasing a manual operation. Remove version bump checks on PRs, and only enforce them on release by running the same lint workflow as part of the release.