### PR TITLE
Fix pgbouncer password override

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.69.0
+version: 0.69.1
 appVersion: 2.159.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/secrets-pgbouncer.yaml
+++ b/charts/flagsmith/templates/secrets-pgbouncer.yaml
@@ -22,5 +22,9 @@ data:
   POSTGRESQL_HOST: {{ $hostParts._0 | b64enc | quote }}
   POSTGRESQL_DATABASE: {{ $urlParts.path | trimAll "/" | b64enc | quote }}
   POSTGRESQL_USER: {{ $userParts._0 | b64enc | quote }}
+  {{- if .Values.pgbouncer.passwordOverride }}
+  POSTGRESQL_PASSWORD: {{ .Values.pgbouncer.passwordOverride | b64enc | quote }}
+  {{- else }}
   POSTGRESQL_PASSWORD: {{ $userParts._1 | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -233,6 +233,8 @@ pgbouncer:
     imagePullSecrets: []
   replicaCount: 1
   deploymentStrategy: null
+  # Optional: Use to override the password directly instead of extracting from the database URL
+  passwordOverride: ""
   podAnnotations: {}
   resources: {}
   podLabels: {}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ X ] I have filled in the "Changes" section below?
- [ X ] I have filled in the "How did you test this code" section below?
- [ X ] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes

Fixes issues with special characters in database passwords when using pgbouncer. The fix should be backwards compatible as well. Introduces the option to specify 'passwordOverride' needed because of the issue described here : https://github.com/Flagsmith/flagsmith-charts/issues/163

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Manually : 
You can go to the chart folder and do : 
1. `helm template flagsmith --set pgbouncer.enabled=true --set databaseExternal.enabled=true --set databaseExternal.host=test --set databaseExternal.username=test --set databaseExternal.database=test --set databaseExternal.password=test --set=pgbouncer.passwordOverride='test%!asd' --output-dir ./output --debug` - This should override the test password.
2. And you can also verify that the code works without the password override using : `helm template flagsmith --set pgbouncer.enabled=true --set databaseExternal.enabled=true --set databaseExternal.host=test --set databaseExternal.username=test --set databaseExternal.database=test --set databaseExternal.password=test --output-dir ./output --debug `
3. Look at each output in the output folder.

Closes #163 

