### PR TITLE
fix: Task processor probe timeouts are too optimistic

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.70.0
+version: 0.71.0
 appVersion: 2.162.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -92,7 +92,7 @@ api:
     adminEmail: null
     organisationName: null
     projectName: null
-    extraSpec: {} # Will be added to `spec` for `flagsmith-api` deployment. 
+    extraSpec: {} # Will be added to `spec` for `flagsmith-api` deployment.
 
 frontend:
   # Set this to `false` to switch off the frontend (deployment,
@@ -168,13 +168,13 @@ taskProcessor:
     initialDelaySeconds: 5
     periodSeconds: 10
     successThreshold: 1
-    timeoutSeconds: 2
+    timeoutSeconds: 30
   readinessProbe:
     failureThreshold: 10
     initialDelaySeconds: 1
     periodSeconds: 10
     successThreshold: 1
-    timeoutSeconds: 2
+    timeoutSeconds: 30
 
   podAnnotations: {}
   resources: {}
@@ -199,7 +199,7 @@ taskProcessor:
   extraEnv: {}
   extraVolumes: []
   volumeMounts: []
-  extraSpec: {} # Will be added to `spec` for `flagsmith-task-processor` deployment. 
+  extraSpec: {} # Will be added to `spec` for `flagsmith-task-processor` deployment.
 
 devPostgresql:
   enabled: true
@@ -274,14 +274,14 @@ pgbouncer:
 influxdb2:
   enabled: true
   adminUser:
-    organization: 'influxdata'
-    bucket: 'default'
-    user: 'admin'
-    retention_policy: '0s'
+    organization: "influxdata"
+    bucket: "default"
+    user: "admin"
+    retention_policy: "0s"
     ## Leave empty to generate a random password and token.
     ## Or fill any of these values to use fixed values.
-    password: ''
-    token: ''
+    password: ""
+    token: ""
     ## The password and token are obtained from an existing secret. The expected
     ## keys are `admin-password` and `admin-token`.
     ## If set, the password and token values above are ignored.


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
      release branch

## Changes

Increases task processor liveness and readiness probe timeout to 30s.

## How did you test this code?

Reviewed the resulting pod specs.