### PR TITLE
fix: Do not deploy SSE k8s service if SSE is disabled

### DIFF
--- a/charts/flagsmith/templates/service-sse.yaml
+++ b/charts/flagsmith/templates/service-sse.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.sse.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -19,3 +20,4 @@ spec:
       name: http
   selector: {{- include "flagsmith.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: sse
+{{- end }}


### PR DESCRIPTION
Noticed that the default values.yaml causes a Kubernetes service for SSE to be created, which does nothing. This PR fixes this.