### PR TITLE
chore: Remove requirement to bump chart version in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,6 @@ Thanks for submitting a PR! Please check the boxes below:
 
 - [ ] I have filled in the "Changes" section below?
 - [ ] I have filled in the "How did you test this code" section below?
-- [ ] I have bumped the version number in `/charts/flagsmith/Chart.yaml` in the section `version` or I'm merging to a
-      release branch
 
 ## Changes
 


### PR DESCRIPTION
Not needed anymore after https://github.com/Flagsmith/flagsmith-charts/pull/313 was merged.