### PR TITLE
ci: Fail release workflow if no new releases were published

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,6 +40,13 @@ jobs:
         run: ct lint --config ct.yaml --lint-conf lintconf.yaml
 
       - name: Run chart-releaser
+        id: chart-releaser
         uses: helm/chart-releaser-action@v1.2.0
         env:
           CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Check if release was published
+        if: steps.chart-releaser.outputs.changed_charts == ''
+        run: |
+          echo "No new releases were published. If a tag and/or release already exist for this version but they have not been published to the Helm repository, delete them and run this workflow again."
+          exit 1


### PR DESCRIPTION
We previously tried to create a release by running the release workflow after manually creating a tag/release: https://github.com/Flagsmith/flagsmith-charts/actions/runs/13566028719/job/37919249460

This did not work because chart-releaser-action always creates the tag/release, with no option to change this behaviour. However, the release workflow still succeeded, which is confusing.

This PR makes it so that the release workflow fails if no releases were published, which should make this situation easier to understand and manually correct if it happens again.

A better solution would be to fully implement release-please, which I understand means we'd need to implement a more manual release pipeline like this random repository: https://github.com/Mailu/helm-charts/blob/master/.github/workflows/publish-chart.yaml