### PR TITLE
feat: Support new Task processor readiness/liveness probes

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.71.0
-appVersion: 2.166.0
+version: 0.72.0
+appVersion: 2.167.1
 dependencies:
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -86,22 +86,20 @@ spec:
         env: {{ include (print $.Template.BasePath "/_task_processor_environment.yaml") . | nindent 8 }}
         livenessProbe:
           failureThreshold: {{ .Values.taskProcessor.livenessProbe.failureThreshold }}
-          exec:
-            command:
-              - python
-              - manage.py
-              - checktaskprocessorthreadhealth
+          httpGet:
+            path: /health/liveness
+            port: {{ .Values.service.taskProcessor.port }}
+            scheme: HTTP
           initialDelaySeconds: {{ .Values.taskProcessor.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.taskProcessor.livenessProbe.periodSeconds }}
           successThreshold: {{ .Values.taskProcessor.livenessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.taskProcessor.livenessProbe.timeoutSeconds }}
         readinessProbe:
           failureThreshold: {{ .Values.taskProcessor.readinessProbe.failureThreshold }}
-          exec:
-            command:
-              - python
-              - manage.py
-              - checktaskprocessorthreadhealth
+          httpGet:
+            path: /health/readiness
+            port: {{ .Values.service.taskProcessor.port }}
+            scheme: HTTP
           initialDelaySeconds: {{ .Values.taskProcessor.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.taskProcessor.readinessProbe.periodSeconds }}
           successThreshold: {{ .Values.taskProcessor.readinessProbe.successThreshold }}

--- a/charts/flagsmith/templates/service-task-processor.yaml
+++ b/charts/flagsmith/templates/service-task-processor.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "flagsmith.fullname" . }}-task-processor
+  {{- $annotations := include "flagsmith.annotations" ( dict "customAnnotations" .Values.service.taskProcessor.annotations "commonValues" .Values.common ) }}
+  {{- with $annotations }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "flagsmith.labels" . | nindent 4 }}
+    app.kubernetes.io/component: task-processor
+spec:
+  type: {{ .Values.service.taskProcessor.type }}
+  ports:
+    - port: {{ .Values.service.taskProcessor.port }}
+      targetPort: {{ .Values.service.taskProcessor.port }}
+      protocol: TCP
+      name: http
+  selector: {{- include "flagsmith.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: task-processor

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -387,6 +387,10 @@ service:
     type: ClusterIP
     port: 8000
     annotations: {}
+  taskProcessor:
+    type: ClusterIP
+    port: 8000
+    annotations: {}
 
 hpa:
   api:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

This PR enables support for new HTTP-based Task Processor liveness and readiness probes.
 
## How did you test this code?

Ran `helm install` on a local `minikube` cluster, observed new service and expected changes to `task-processor` deployment. 