### PR TITLE
feat: `exec` liveness probes

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flagsmith
 description: Flagsmith
 type: application
-version: 0.74.0
+version: 0.75.0
 appVersion: 2.173.0
 dependencies:
   - name: postgresql

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -133,10 +133,14 @@ spec:
         env: {{ include (print $.Template.BasePath "/_api_environment.yaml") . | nindent 8 }}
         livenessProbe:
           failureThreshold: {{ .Values.api.livenessProbe.failureThreshold }}
+          {{- if .Values.api.livenessProbe.exec }}
+          exec: {{ .Values.api.livenessProbe.exec | toYaml | nindent 12 }}
+          {{- else if .Values.api.livenessProbe.path }}
           httpGet:
             path: {{ .Values.api.livenessProbe.path }}
             port: {{ .Values.service.api.port }}
             scheme: HTTP
+          {{- end }}
           initialDelaySeconds: {{ .Values.api.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.api.livenessProbe.periodSeconds }}
           successThreshold: {{ .Values.api.livenessProbe.successThreshold }}

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -132,7 +132,6 @@ spec:
         - containerPort: {{ .Values.service.api.port }}
         env: {{ include (print $.Template.BasePath "/_api_environment.yaml") . | nindent 8 }}
         livenessProbe:
-          failureThreshold: {{ .Values.api.livenessProbe.failureThreshold }}
           {{- if .Values.api.livenessProbe.exec }}
           exec: {{ .Values.api.livenessProbe.exec | toYaml | nindent 12 }}
           {{- else if .Values.api.livenessProbe.path }}
@@ -141,6 +140,7 @@ spec:
             port: {{ .Values.service.api.port }}
             scheme: HTTP
           {{- end }}
+          failureThreshold: {{ .Values.api.livenessProbe.failureThreshold }}
           initialDelaySeconds: {{ .Values.api.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.api.livenessProbe.periodSeconds }}
           successThreshold: {{ .Values.api.livenessProbe.successThreshold }}

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -85,11 +85,16 @@ spec:
         - containerPort: {{ .Values.service.taskProcessor.port }}
         env: {{ include (print $.Template.BasePath "/_task_processor_environment.yaml") . | nindent 8 }}
         livenessProbe:
-          failureThreshold: {{ .Values.taskProcessor.livenessProbe.failureThreshold }}
+          {{- $exec := .Values.taskProcessor.livenessProbe.exec | default .Values.api.livenessProbe.exec }}
+          {{- if $exec }}
+          exec: {{ $exec | toYaml | nindent 12 }}
+          {{- else }}
           httpGet:
             path: /health/liveness
             port: {{ .Values.service.taskProcessor.port }}
             scheme: HTTP
+          {{- end }}
+          failureThreshold: {{ .Values.taskProcessor.livenessProbe.failureThreshold }}
           initialDelaySeconds: {{ .Values.taskProcessor.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.taskProcessor.livenessProbe.periodSeconds }}
           successThreshold: {{ .Values.taskProcessor.livenessProbe.successThreshold }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -196,6 +196,9 @@ taskProcessor:
   queuePopSize: null
 
   livenessProbe:
+    # exec describes an ExecAction command which will run inside the API container.
+    # See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe
+    exec: {}
     failureThreshold: 5
     initialDelaySeconds: 5
     periodSeconds: 10

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -76,7 +76,11 @@ api:
     # runAsUser: 1000
     # runAsGroup: 1000
   livenessProbe:
+    # path is the API path to be used for health checks. Used if exec is not set.
     path: /health/liveness
+    # exec describes an ExecAction command which will run inside the API container.
+    # See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe
+    exec: {}
     failureThreshold: 5
     initialDelaySeconds: 5
     periodSeconds: 10

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -197,6 +197,7 @@ taskProcessor:
 
   livenessProbe:
     # exec describes an ExecAction command which will run inside the API container.
+    # Defaults to api.livenessProbe.exec.
     # See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe
     exec: {}
     failureThreshold: 5


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

This PR adds new values `api.livenessProbe.exec` and `taskProcessor.livenessProbe.exec`. These accept an ExecAction that performs a health check by running a command inside a container: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe

This lets customers use TCP healthchecks for the API and task processor, which are not affected by the Gunicorn worker HTTP request queue. For example, this performs a liveness check by using Python to connect to Gunicorn's TCP socket locally:

```yaml
api:
  livenessProbe:
    exec:
      command:
      - /usr/bin/python
      - -c
      - |
        import socket
        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
        sock.settimeout(1)
        sock.connect(('localhost', 8000))
        sock.close()
```

## How did you test this code?

Tested by using these new values in the self-hosted Helm example: https://github.com/Flagsmith/self-hosted/pull/21/commits/5371ad6601f537292d6700aa2ffef530a1648dbc

We can then see this liveness probe being used in the output of `kubectl describe pods`:

```
❯ kubectl describe pods --namespace flagsmith flagsmith-api-7797458f98-hxblw
[...]
Containers:
  flagsmith-api:
    Container ID:  docker://7f6e05575d083c02df43052abcedf2a7d3704fe68d79bd241cda8b688c3a284d
    Image:         quay.io/flagsmithofficial/flagsmith-enterprise-api:2.173.0
    Image ID:      docker-pullable://quay.io/flagsmithofficial/flagsmith-enterprise-api@sha256:732f1cca25bcf6a063f764fd4496cb06ae59238650ddb3954d9e0aa182ac4d5d
    Port:          8000/TCP
    Host Port:     0/TCP
    Args:
      serve
    State:          Running
      Started:      Tue, 22 Apr 2025 15:27:23 -0300
    Ready:          True
    Restart Count:  0
    Liveness:       exec [/usr/bin/python -c import socket
sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
sock.settimeout(1)
sock.connect(('localhost', 8000))
sock.close()
] delay=5s timeout=2s period=10s #success=1 #failure=5
    Readiness:  http-get http://:8000/health/readiness delay=1s timeout=2s period=10s #success=1 #failure=10
```

```
❯ kubectl describe pods --namespace flagsmith flagsmith-task-processor-89f89fbcd-tdgl6
[...]
Containers:
  flagsmith-task-processor:
    Container ID:  docker://f62a51cb25f81a398e5acca1f885daead9684a08c2bef91a832ea86050e403dc
    Image:         quay.io/flagsmithofficial/flagsmith-enterprise-api:2.174.0
    Image ID:      docker-pullable://quay.io/flagsmithofficial/flagsmith-enterprise-api@sha256:0711b5d1790ee25a4b9fb1dded70f3a5a49453592e6b37517f35b5960656db33
    Port:          8000/TCP
    Host Port:     0/TCP
    Command:
      ./scripts/run-docker.sh
    Args:
      run-task-processor
    State:          Running
      Started:      Tue, 22 Apr 2025 15:27:15 -0300
    Ready:          True
    Restart Count:  0
    Liveness:       exec [/usr/bin/python -c import socket
sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
sock.settimeout(1)
sock.connect(('localhost', 8000))
sock.close()
] delay=5s timeout=30s period=10s #success=1 #failure=5
    Readiness:  http-get http://:8000/health/readiness delay=1s timeout=30s period=10s #success=1 #failure=10
```
