### PR TITLE
chore(appVersion): bump default app version to 2.188.1

### DIFF
--- a/charts/flagsmith/Chart.yaml
+++ b/charts/flagsmith/Chart.yaml
@@ -3,7 +3,7 @@ name: flagsmith
 description: Flagsmith
 type: application
 version: 0.74.0
-appVersion: 2.184.0
+appVersion: 2.188.1
 dependencies:
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
to pickup latest app version:

https://github.com/Flagsmith/flagsmith/releases/tag/v2.188.1

Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

bumping appVersion to 2.188.1 so the default image version includes changes for CRDB support.

## How did you test this code?

Bumped locally via values change.
