### PR TITLE
chore(ci): automate publishing again

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,20 +6,45 @@ on:
     tags:
       - flagsmith-*.*.*
 
+env:
+  HELM_VERSION: v3.12.3
+
 jobs:
   release:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repo
+      - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # required for full tag history
+          fetch-depth: 0
 
-      - name: Set up Helm
+      - name: Install Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.12.3
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Add chart repo dependencies
+        # Note: this repos should match with the repos set in ct.yaml
+        # See https://github.com/Flagsmith/flagsmith-charts/issues/105
+        run: |
+          helm repo add stable https://charts.helm.sh/stable
+          helm repo add influxdb2 https://helm.influxdata.com/
+          helm repo add kiwigrid https://kiwigrid.github.io
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config ct.yaml --lint-conf lintconf.yaml
+
+      # The following steps replace those originally handled by helm.chart-releaser-action
+      # Now that release-please is handling the generation of the release and tag, we just need
+      # to build the charts, upload them to the release created by release-please, and then
+      # update the gh-pages branch to update the helm repo.
 
       - name: Build chart
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,9 @@ name: Release Charts
 
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - flagsmith-*.*.*
 
 jobs:
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,6 +46,9 @@ jobs:
         id: chart-releaser
         uses: helm/chart-releaser-action@v1
         with:
+          # Since release please will create the release, we are just using chart-releaser
+          # to upload the charts. By default, it will skip upload if it finds an existing
+          # release / tag.
           skip_existing: false
         env:
           CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,14 +38,13 @@ jobs:
         run: |
           git fetch origin gh-pages
           git worktree add gh-pages origin/gh-pages
-          cp .cr-release-packages/*.tgz gh-pages/
           helm repo index gh-pages \
             --merge gh-pages/index.yaml \
             --url "https://github.com/Flagsmith/flagsmith-charts/releases/download/$GITHUB_REF_NAME"
           cd gh-pages
           git config user.name "flagsmithdev"
           git config user.email "engineering@flagsmith.com"
-          git add .
+          git add gh-pages/index.yaml
           git commit -m "Add Helm chart for $GITHUB_REF_NAME"
           git push origin HEAD:gh-pages
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,9 +35,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update GitHub Pages index
-        uses: helm/chart-releaser-action@v1
-        with:
-          charts_dir: charts
-          skip_existing: false
+        run: |
+          git fetch origin gh-pages
+          git worktree add gh-pages origin/gh-pages
+          cp packaged/*.tgz gh-pages/
+          helm repo index gh-pages --merge gh-pages/index.yaml
+          cd gh-pages
+          git add .
+          git commit -m "Add Helm chart for $GITHUB_REF_NAME"
+          git push origin gh-pages
         env:
-          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,9 @@ jobs:
           git fetch origin gh-pages
           git worktree add gh-pages origin/gh-pages
           cp .cr-release-packages/*.tgz gh-pages/
-          helm repo index gh-pages --merge gh-pages/index.yaml
+          helm repo index gh-pages \
+            --merge gh-pages/index.yaml \
+            --url "https://github.com/Flagsmith/flagsmith-charts/releases/download/$GITHUB_REF_NAME"
           cd gh-pages
           git config user.name "flagsmithdev"
           git config user.email "engineering@flagsmith.com"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Run chart-releaser
         id: chart-releaser
-        uses: helm/chart-releaser-action@v1.2.0
+        uses: helm/chart-releaser-action@v1
+        with:
+          skip_existing: false
         env:
           CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,6 +41,8 @@ jobs:
           cp .cr-release-packages/*.tgz gh-pages/
           helm repo index gh-pages --merge gh-pages/index.yaml
           cd gh-pages
+          git config user.name "flagsmithdev"
+          git config user.email "engineering@flagsmith.com"
           git add .
           git commit -m "Add Helm chart for $GITHUB_REF_NAME"
           git push origin gh-pages

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,7 @@ jobs:
         run: |
           git fetch origin gh-pages
           git worktree add gh-pages origin/gh-pages
+          cp .cr-release-packages/*.tgz gh-pages/
           helm repo index gh-pages \
             --merge gh-pages/index.yaml \
             --url "https://github.com/Flagsmith/flagsmith-charts/releases/download/$GITHUB_REF_NAME"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
         run: |
           git fetch origin gh-pages
           git worktree add gh-pages origin/gh-pages
-          cp .cr-release-packageskaged/*.tgz gh-pages/
+          cp .cr-release-packages/*.tgz gh-pages/
           helm repo index gh-pages --merge gh-pages/index.yaml
           cd gh-pages
           git add .

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
         run: |
           git fetch origin gh-pages
           git worktree add gh-pages origin/gh-pages
-          cp packaged/*.tgz gh-pages/
+          cp .cr-release-packageskaged/*.tgz gh-pages/
           helm repo index gh-pages --merge gh-pages/index.yaml
           cd gh-pages
           git add .
@@ -46,4 +46,3 @@ jobs:
           git push origin gh-pages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
           cd gh-pages
           git config user.name "flagsmithdev"
           git config user.email "engineering@flagsmith.com"
-          git add gh-pages/index.yaml
+          git add index.yaml
           git commit -m "Add Helm chart for $GITHUB_REF_NAME"
           git push origin HEAD:gh-pages
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,6 @@
 name: Release Charts
 
 on:
-  workflow_dispatch:
   push:
     tags:
       - flagsmith-*.*.*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,46 +9,35 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: Checkout repo
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 0  # required for full tag history
 
-      - name: Configure Git
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.12.3
+
+      - name: Build chart
         run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          mkdir -p .cr-release-packages
+          helm dependency update charts/flagsmith
+          helm package charts/flagsmith --destination .cr-release-packages
 
-      - name: Install Helm
-        uses: azure/setup-helm@v1
+      - name: Upload chart to GitHub Release
+        uses: softprops/action-gh-release@v1
         with:
-          version: v3.5.4
+          files: .cr-release-packages/*.tgz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Add chart repo dependencies
-        # Note: this repos should match with the repos set in ct.yaml
-        # See https://github.com/Flagsmith/flagsmith-charts/issues/105
-        run: |
-          helm repo add stable https://charts.helm.sh/stable
-          helm repo add influxdb2 https://helm.influxdata.com/
-          helm repo add kiwigrid https://kiwigrid.github.io
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-
-      - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.0.1
-        with:
-          version: v3.3.0
-
-      - name: Run chart-testing (lint)
-        run: ct lint --config ct.yaml --lint-conf lintconf.yaml
-
-      - name: Run chart-releaser
-        id: chart-releaser
+      - name: Update GitHub Pages index
         uses: helm/chart-releaser-action@v1
         with:
-          # Since release please will create the release, we are just using chart-releaser
-          # to upload the charts. By default, it will skip upload if it finds an existing
-          # release / tag.
+          charts_dir: charts
           skip_existing: false
         env:
-          CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,6 @@ jobs:
           git config user.email "engineering@flagsmith.com"
           git add .
           git commit -m "Add Helm chart for $GITHUB_REF_NAME"
-          git push origin gh-pages
+          git push origin HEAD:gh-pages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

This PR turned out to be way more painful than I expected. The original goal was to revert [this PR](https://github.com/Flagsmith/flagsmith-charts/pull/313), which was added before we had release please to group releases. The key issue though is that release please and helm's chart-releaser-action do not work well together as they both want to create the github release and tag. 

Useful references:
 - https://github.com/helm/chart-releaser-action/issues/159
 - https://github.com/Mailu/helm-charts/blob/master/.github/workflows/publish-chart.yaml

The new workflow steps added in this PR (generated with help from ChatGPT) essentially replace the work of the chart releaser action. The new flow is: 

 1. Release please release PR is merged
 2. Release please action creates the github release and tag (in the format flagsmith-X.Y.Z for consistency)
 3. Release workflow is triggered on tag creation
 4. Release workflow builds the chart binary and uploads to the release created by release please
 5. Release workflow updates the gh-pages branch with new meta information on the release
 6. Change to gh-pages branch automatically triggers a rebuild of the GH pages site (which acts as the helm repo for flagsmith charts)

## How did you test this code?

I've tested this by manually creating the flagsmith-0.75.0 tag from this branch, but the real test will be once we merge the next release please PR. 
