### PR TITLE
chore(ci): revert version changes in release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,8 +2,6 @@ name: Release Charts
 
 on:
   push:
-    branches:
-      - chore(ci)/revert-version-changes-in-release-pipeline
     tags:
       - flagsmith-*.*.*
 
@@ -50,26 +48,26 @@ jobs:
           helm dependency update charts/flagsmith
           helm package charts/flagsmith --destination .cr-release-packages
 
-      # - name: Upload chart to GitHub Release
-      #   uses: softprops/action-gh-release@v1
-      #   with:
-      #     files: .cr-release-packages/*.tgz
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload chart to GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: .cr-release-packages/*.tgz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Update GitHub Pages index
-      #   run: |
-      #     git fetch origin gh-pages
-      #     git worktree add gh-pages origin/gh-pages
-      #     cp .cr-release-packages/*.tgz gh-pages/
-      #     helm repo index gh-pages \
-      #       --merge gh-pages/index.yaml \
-      #       --url "https://github.com/Flagsmith/flagsmith-charts/releases/download/$GITHUB_REF_NAME"
-      #     cd gh-pages
-      #     git config user.name "flagsmithdev"
-      #     git config user.email "engineering@flagsmith.com"
-      #     git add index.yaml
-      #     git commit -m "Add Helm chart for $GITHUB_REF_NAME"
-      #     git push origin HEAD:gh-pages
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update GitHub Pages index
+        run: |
+          git fetch origin gh-pages
+          git worktree add gh-pages origin/gh-pages
+          cp .cr-release-packages/*.tgz gh-pages/
+          helm repo index gh-pages \
+            --merge gh-pages/index.yaml \
+            --url "https://github.com/Flagsmith/flagsmith-charts/releases/download/$GITHUB_REF_NAME"
+          cd gh-pages
+          git config user.name "flagsmithdev"
+          git config user.email "engineering@flagsmith.com"
+          git add index.yaml
+          git commit -m "Add Helm chart for $GITHUB_REF_NAME"
+          git push origin HEAD:gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
       - flagsmith-*.*.*
 
 env:
-  HELM_VERSION: v3.12.3
+  HELM_VERSION: v3.5.4
 
 jobs:
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
           helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2
+        uses: helm/chart-testing-action@v2.0.1
         with:
           version: v3.3.0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,9 @@ on:
     tags:
       - flagsmith-*.*.*
 
+env:
+  HELM_VERSION: v3.12.3
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -22,7 +25,7 @@ jobs:
         uses: azure/setup-helm@v1
         with:
           # TODO: standardise the version of Helm used across this workflow
-          version: v3.5.4
+          version: ${{ env.HELM_VERSION }}
 
       - name: Add chart repo dependencies
         # Note: this repos should match with the repos set in ct.yaml
@@ -37,7 +40,7 @@ jobs:
         # TODO: relax this to just v2
         uses: helm/chart-testing-action@v2.0.1
         with:
-          version: v3.3.0
+          version: ${{ env.HELM_VERSION }}
 
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml --lint-conf lintconf.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,11 +2,10 @@ name: Release Charts
 
 on:
   push:
+    branches:
+      - chore(ci)/revert-version-changes-in-release-pipeline
     tags:
       - flagsmith-*.*.*
-
-env:
-  HELM_VERSION: v3.12.3
 
 jobs:
   release:
@@ -19,9 +18,11 @@ jobs:
           fetch-depth: 0
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        # TODO: bump this to v3
+        uses: azure/setup-helm@v1
         with:
-          version: ${{ env.HELM_VERSION }}
+          # TODO: standardise the version of Helm used across this workflow
+          version: v3.5.4
 
       - name: Add chart repo dependencies
         # Note: this repos should match with the repos set in ct.yaml
@@ -33,9 +34,10 @@ jobs:
           helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2
+        # TODO: relax this to just v2
+        uses: helm/chart-testing-action@v2.0.1
         with:
-          version: ${{ env.HELM_VERSION }}
+          version: v3.3.0
 
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml --lint-conf lintconf.yaml
@@ -51,26 +53,26 @@ jobs:
           helm dependency update charts/flagsmith
           helm package charts/flagsmith --destination .cr-release-packages
 
-      - name: Upload chart to GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: .cr-release-packages/*.tgz
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Upload chart to GitHub Release
+      #   uses: softprops/action-gh-release@v1
+      #   with:
+      #     files: .cr-release-packages/*.tgz
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update GitHub Pages index
-        run: |
-          git fetch origin gh-pages
-          git worktree add gh-pages origin/gh-pages
-          cp .cr-release-packages/*.tgz gh-pages/
-          helm repo index gh-pages \
-            --merge gh-pages/index.yaml \
-            --url "https://github.com/Flagsmith/flagsmith-charts/releases/download/$GITHUB_REF_NAME"
-          cd gh-pages
-          git config user.name "flagsmithdev"
-          git config user.email "engineering@flagsmith.com"
-          git add index.yaml
-          git commit -m "Add Helm chart for $GITHUB_REF_NAME"
-          git push origin HEAD:gh-pages
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Update GitHub Pages index
+      #   run: |
+      #     git fetch origin gh-pages
+      #     git worktree add gh-pages origin/gh-pages
+      #     cp .cr-release-packages/*.tgz gh-pages/
+      #     helm repo index gh-pages \
+      #       --merge gh-pages/index.yaml \
+      #       --url "https://github.com/Flagsmith/flagsmith-charts/releases/download/$GITHUB_REF_NAME"
+      #     cd gh-pages
+      #     git config user.name "flagsmithdev"
+      #     git config user.email "engineering@flagsmith.com"
+      #     git add index.yaml
+      #     git commit -m "Add Helm chart for $GITHUB_REF_NAME"
+      #     git push origin HEAD:gh-pages
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,9 +7,6 @@ on:
     tags:
       - flagsmith-*.*.*
 
-env:
-  HELM_VERSION: v3.5.4
-
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -21,11 +18,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install Helm
-        # TODO: bump this to v3
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
-          # TODO: standardise the version of Helm used across this workflow
-          version: ${{ env.HELM_VERSION }}
+          version: v3.5.4
 
       - name: Add chart repo dependencies
         # Note: this repos should match with the repos set in ct.yaml
@@ -37,10 +32,9 @@ jobs:
           helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Set up chart-testing
-        # TODO: relax this to just v2
-        uses: helm/chart-testing-action@v2.0.1
+        uses: helm/chart-testing-action@v2
         with:
-          version: ${{ env.HELM_VERSION }}
+          version: v3.3.0
 
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml --lint-conf lintconf.yaml


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

This PR reverts most of the version changes that were bundled into [this PR](https://github.com/Flagsmith/flagsmith-charts/pull/398) in order to fix the issue seen in the release action after merging the latest PR from release please [here](https://github.com/Flagsmith/flagsmith-charts/actions/runs/16524804951). 

## How did you test this code?

I updated the workflow to run on pushes from this branch, and commented out the actual release section that would fail without being triggered by a tag. The successful run (at least to confirm that the issue seen in the above linked job is resolved) can be seen [here](https://github.com/Flagsmith/flagsmith-charts/actions/runs/16525085308/job/46736225392).  
