### PR TITLE
feat: Support readiness probe overrides for API and Task processor deployments

### DIFF
--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -148,11 +148,15 @@ spec:
           successThreshold: {{ .Values.api.livenessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.api.livenessProbe.timeoutSeconds }}
         readinessProbe:
-          failureThreshold: {{ .Values.api.readinessProbe.failureThreshold }}
+          {{- if .Values.api.readinessProbe.exec }}
+          exec: {{ .Values.api.readinessProbe.exec | toYaml | nindent 12 }}
+          {{- else if .Values.api.readinessProbe.path }}
           httpGet:
             path: {{ .Values.api.readinessProbe.path }}
             port: {{ .Values.service.api.port }}
             scheme: HTTP
+          {{- end }}
+          failureThreshold: {{ .Values.api.readinessProbe.failureThreshold }}
           initialDelaySeconds: {{ .Values.api.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.api.readinessProbe.periodSeconds }}
           successThreshold: {{ .Values.api.readinessProbe.successThreshold }}

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -56,7 +56,7 @@ spec:
       {{- if .Values.taskProcessor.schedulerName }}
       schedulerName: "{{ .Values.taskProcessor.schedulerName }}"
       {{- end }}
-      {{- with .Values.taskProcessor.image.imagePullSecrets | default .Values.api.image.imagePullSecrets | default .Values.global.image.imagePullSecrets }}
+      {{- with .Values.taskProcessor.image.imagePullSecrets | default .Values.extraObjectsimagePullSecrets | default .Values.global.image.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -90,7 +90,7 @@ spec:
           exec: {{ $exec | toYaml | nindent 12 }}
           {{- else }}
           httpGet:
-            path: /health/liveness
+            path: /health/liveness/
             port: {{ .Values.service.taskProcessor.port }}
             scheme: HTTP
           {{- end }}
@@ -100,11 +100,16 @@ spec:
           successThreshold: {{ .Values.taskProcessor.livenessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.taskProcessor.livenessProbe.timeoutSeconds }}
         readinessProbe:
+          {{- $exec := .Values.taskProcessor.readinessProbe.exec | default .Values.api.readinessProbe.exec }}
           failureThreshold: {{ .Values.taskProcessor.readinessProbe.failureThreshold }}
+          {{- if $exec }}
+          exec: {{ $exec | toYaml | nindent 12 }}
+          {{- else }}
           httpGet:
-            path: /health/readiness
+            path: /health/readiness/
             port: {{ .Values.service.taskProcessor.port }}
             scheme: HTTP
+          {{- end }}
           initialDelaySeconds: {{ .Values.taskProcessor.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.taskProcessor.readinessProbe.periodSeconds }}
           successThreshold: {{ .Values.taskProcessor.readinessProbe.successThreshold }}

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -56,7 +56,7 @@ spec:
       {{- if .Values.taskProcessor.schedulerName }}
       schedulerName: "{{ .Values.taskProcessor.schedulerName }}"
       {{- end }}
-      {{- with .Values.taskProcessor.image.imagePullSecrets | default .Values.extraObjectsimagePullSecrets | default .Values.global.image.imagePullSecrets }}
+      {{- with .Values.taskProcessor.image.imagePullSecrets | default .Values.api.image.imagePullSecrets | default .Values.global.image.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -77,7 +77,7 @@ api:
     # runAsGroup: 1000
   livenessProbe:
     # path is the API path to be used for health checks. Used if exec is not set.
-    path: /health/liveness
+    path: /health/liveness/
     # exec describes an ExecAction command which will run inside the API container.
     # See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe
     exec: {}
@@ -87,7 +87,10 @@ api:
     successThreshold: 1
     timeoutSeconds: 2
   readinessProbe:
-    path: /health/readiness
+    path: /health/readiness/
+    # exec describes an ExecAction command which will run inside the API container.
+    # See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe
+    exec: {}
     failureThreshold: 10
     initialDelaySeconds: 1
     periodSeconds: 10
@@ -206,6 +209,10 @@ taskProcessor:
     successThreshold: 1
     timeoutSeconds: 30
   readinessProbe:
+    # exec describes an ExecAction command which will run inside the API container.
+    # Defaults to api.readinessProbe.exec.
+    # See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe
+    exec: {}
     failureThreshold: 10
     initialDelaySeconds: 1
     periodSeconds: 10
@@ -397,14 +404,14 @@ sse:
     # runAsUser: 1000
     # runAsGroup: 1000
   livenessProbe:
-    path: /health/liveness
+    path: /health/liveness/
     failureThreshold: 5
     initialDelaySeconds: 5
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 2
   readinessProbe:
-    path: /health/readiness
+    path: /health/readiness/
     failureThreshold: 10
     initialDelaySeconds: 1
     periodSeconds: 10


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

This PR:

1. Allows to redefine readiness probes for backend deployments just as the liveness ones.
2. Changes default paths for default probes to avoid 301 responses. 


## How did you test this code?

Deployed to a local cluster and verified the resulting manifests manually.