### PR TITLE
fix: use bitnamilegacy repo for postgres and pgbouncer

### DIFF
--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -245,6 +245,10 @@ taskProcessor:
   extraSpec: {} # Will be added to `spec` for `flagsmith-task-processor` deployment.
 
 devPostgresql:
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/postgresql
+    tag: 15.3.0-debian-11-r7
   enabled: true
   serviceAccount:
     create: true
@@ -270,7 +274,7 @@ databaseExternal:
 pgbouncer:
   enabled: false
   image:
-    repository: bitnami/pgbouncer
+    repository: bitnamilegacy/pgbouncer
     tag: 1.16.0
     imagePullPolicy: ""
     imagePullSecrets: []

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -246,7 +246,6 @@ taskProcessor:
 
 devPostgresql:
   image:
-    registry: docker.io
     repository: bitnamilegacy/postgresql
     tag: 15.3.0-debian-11-r7
   enabled: true


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

This implements a temporary fix due to the changes introduced by this [1]. I also looked into other ways to handle this, e.g., using a different image with the same Bitnami chart or moving to a different chart. All of those options also feel like temporary fixes, so we might as well move to bitnamilegacy for now. The permanent fix would be to move away from the Bitnami chart entirely, use the Docker images directly, and handle the minimal setup that the Bitnami charts currently provide.
[1]: https://github.com/Flagsmith/flagsmith-charts/issues/386

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Installed this chart on minikube 
