### PR TITLE
fix: use bitnamilegacy repo for kubectl

### DIFF
--- a/charts/flagsmith/templates/django-secret-init/job.yaml
+++ b/charts/flagsmith/templates/django-secret-init/job.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: {{ include "flagsmith.api.secretKeySecretName" . }}
       containers:
         - name: secret-creator
-          image: bitnami/kubectl:latest
+          image: bitnamilegacy/kubectl:latest
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
- fix: use bitnamilegacy repo for kubectl

Thanks for submitting a PR! Please check the boxes below:

- [x ] I have filled in the "Changes" section below?
- [ x] I have filled in the "How did you test this code" section below?

## Changes

use bitnamilegacy repo for kubectl - bitnami pulled kubectl from their repo. as a result all deployments are currently failing

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

change is trivial. we are in the process of preparing a local fork while this is merged and we upgrade our chart to the latest release.