### PR TITLE
feat: add namespaceOverride support for sub-chart deployments

### DIFF
--- a/charts/flagsmith/templates/NOTES.txt
+++ b/charts/flagsmith/templates/NOTES.txt
@@ -5,14 +5,14 @@ for more configuration options.
 
 To access Flagsmith using port-forwarding, run:
 
-kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "flagsmith.fullname" . }}-frontend 8080:{{ .Values.service.frontend.port }}
+kubectl -n {{ include "flagsmith.namespace" . }} port-forward svc/{{ include "flagsmith.fullname" . }}-frontend 8080:{{ .Values.service.frontend.port }}
 
 Then access http://localhost:8080 in a browser.
 
 {{- if .Values.api.bootstrap.enabled }}
 To see the password reset link for pre-created admin user, run:
 
-kubectl -n {{ .Release.Namespace }} logs pods/{{ include "flagsmith.fullname" . }}-api -c bootstrap
+kubectl -n {{ include "flagsmith.namespace" . }} logs pods/{{ include "flagsmith.fullname" . }}-api -c bootstrap
 {{- end }}
 
 {{ if not (and .Values.ingress.frontend.enabled .Values.ingress.api.enabled) }}

--- a/charts/flagsmith/templates/_api_environment.yaml
+++ b/charts/flagsmith/templates/_api_environment.yaml
@@ -115,5 +115,5 @@
     secretKeyRef:
       {{ include "flagsmith.sse.authenticationTokenSecretRef" . | nindent 6}}
 - name: SSE_SERVER_BASE_URL
-  value: http://{{ include "flagsmith.fullname" . }}-sse.{{ .Release.Namespace }}:{{ .Values.service.sse.port }}
+  value: http://{{ include "flagsmith.fullname" . }}-sse.{{ include "flagsmith.namespace" . }}:{{ .Values.service.sse.port }}
 {{- end }}

--- a/charts/flagsmith/templates/_helpers.tpl
+++ b/charts/flagsmith/templates/_helpers.tpl
@@ -7,6 +7,13 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "flagsmith.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
@@ -182,14 +189,14 @@ Set redis port
 Postgres hostname
 */}}
 {{- define "flagsmith.postgres.hostname" -}}
-{{- printf "%s-%s" .Release.Name .Values.devPostgresql.nameOverride -}}.{{ .Release.Namespace }}.svc.cluster.local
+{{- printf "%s-%s" .Release.Name .Values.devPostgresql.nameOverride -}}.{{ include "flagsmith.namespace" . }}.svc.cluster.local
 {{- end -}}
 
 {{/*
 PgBouncer hostname
 */}}
 {{- define "flagsmith.pgbouncer.hostname" -}}
-{{- printf "%s-%s" .Release.Name "pgbouncer" -}}.{{ .Release.Namespace }}.svc.cluster.local
+{{- printf "%s-%s" .Release.Name "pgbouncer" -}}.{{ include "flagsmith.namespace" . }}.svc.cluster.local
 {{- end -}}
 
 {{/*
@@ -221,7 +228,7 @@ If release name contains chart name it will be used as a full name.
 Influxdb hostname
 */}}
 {{- define "flagsmith.influxdb.hostname" -}}
-{{ template "flagsmith.influxdb.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+{{ template "flagsmith.influxdb.fullname" . }}.{{ include "flagsmith.namespace" . }}.svc.cluster.local
 {{- end -}}
 
 {{/*
@@ -249,9 +256,9 @@ Frontend environment
   value: '/'
 {{- if .Values.frontend.apiProxy.enabled }}
 - name: PROXY_API_URL
-  value: http://{{ include "flagsmith.fullname" . }}-api.{{ .Release.Namespace }}:{{ .Values.service.api.port }}
+  value: http://{{ include "flagsmith.fullname" . }}-api.{{ include "flagsmith.namespace" . }}:{{ .Values.service.api.port }}
 - name: FLAGSMITH_PROXY_API_URL
-  value: http://{{ include "flagsmith.fullname" . }}-api.{{ .Release.Namespace }}:{{ .Values.service.api.port }}
+  value: http://{{ include "flagsmith.fullname" . }}-api.{{ include "flagsmith.namespace" . }}:{{ .Values.service.api.port }}
 {{- end }}
 {{- if and .Values._destructiveTests.enabled .Values._destructiveTests.testToken }}
 - name: E2E_TEST_TOKEN_E2E
@@ -259,7 +266,7 @@ Frontend environment
 - name: E2E_TEST_TOKEN
   value: {{ .Values._destructiveTests.testToken | quote }}
 - name: FLAGSMITH_API
-  value: {{ include "flagsmith.fullname" . }}-api.{{ .Release.Namespace }}:{{ .Values.service.api.port }}/api/v1/
+  value: {{ include "flagsmith.fullname" . }}-api.{{ include "flagsmith.namespace" . }}:{{ .Values.service.api.port }}/api/v1/
 - name: ENABLE_INFLUXDB_FEATURES
   value: {{ .Values.influxdb2.enabled | ternary "true" "false" | squote }}
 {{- end }}

--- a/charts/flagsmith/templates/configmap-influxdb-setup.yaml
+++ b/charts/flagsmith/templates/configmap-influxdb-setup.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "flagsmith.namespace" . }}
   name: {{ template "flagsmith.fullname" . }}-influxdb-setup
   {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "flagsmith.namespace" . }}
   name: {{ template "flagsmith.fullname" . }}-api
   {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}

--- a/charts/flagsmith/templates/deployment-frontend.yaml
+++ b/charts/flagsmith/templates/deployment-frontend.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "flagsmith.namespace" . }}
   name: {{ template "flagsmith.fullname" . }}
   {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}

--- a/charts/flagsmith/templates/deployment-pgbouncer.yaml
+++ b/charts/flagsmith/templates/deployment-pgbouncer.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "flagsmith.namespace" . }}
   name: {{ template "flagsmith.fullname" . }}-pgbouncer
   {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}

--- a/charts/flagsmith/templates/deployment-sse.yaml
+++ b/charts/flagsmith/templates/deployment-sse.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "flagsmith.namespace" . }}
   name: {{ template "flagsmith.fullname" . }}-sse
   {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "flagsmith.namespace" . }}
   name: {{ template "flagsmith.fullname" . }}-task-processor
   {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}

--- a/charts/flagsmith/templates/django-secret-init/job.yaml
+++ b/charts/flagsmith/templates/django-secret-init/job.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "flagsmith.api.secretKeySecretName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "flagsmith.namespace" . | quote }}
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
     app.kubernetes.io/component: django-secret-init
@@ -30,7 +30,7 @@ spec:
             - -c
             - |
               SECRET_NAME={{ include "flagsmith.api.secretKeySecretName" . }}
-              NAMESPACE={{ .Release.Namespace }}
+              NAMESPACE={{ include "flagsmith.namespace" . }}
               echo "Checking for secret $SECRET_NAME in namespace $NAMESPACE"
               # Attempt to get the secret; if it fails (exit code != 0), create it.
               if ! kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" -o name; then

--- a/charts/flagsmith/templates/django-secret-init/rbac.yaml
+++ b/charts/flagsmith/templates/django-secret-init/rbac.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "flagsmith.api.secretKeySecretName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "flagsmith.namespace" . | quote }}
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
   annotations:
@@ -18,7 +18,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "flagsmith.api.secretKeySecretName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "flagsmith.namespace" . | quote }}
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
   annotations:
@@ -31,5 +31,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "flagsmith.api.secretKeySecretName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "flagsmith.namespace" . | quote }}
 {{- end }}

--- a/charts/flagsmith/templates/django-secret-init/serviceaccount.yaml
+++ b/charts/flagsmith/templates/django-secret-init/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "flagsmith.api.secretKeySecretName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "flagsmith.namespace" . | quote }}
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
   annotations:

--- a/charts/flagsmith/templates/hpa-api.yaml
+++ b/charts/flagsmith/templates/hpa-api.yaml
@@ -2,7 +2,7 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "flagsmith.namespace" . }}
   name: {{ template "flagsmith.fullname" . }}-api-hpa
 spec:
   scaleTargetRef:

--- a/charts/flagsmith/templates/ingress-api.yaml
+++ b/charts/flagsmith/templates/ingress-api.yaml
@@ -12,7 +12,7 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "flagsmith.namespace" . }}
   name: {{ $fullName }}-api
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}

--- a/charts/flagsmith/templates/ingress-frontend.yaml
+++ b/charts/flagsmith/templates/ingress-frontend.yaml
@@ -12,7 +12,7 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "flagsmith.namespace" . }}
   name: {{ $fullName }}-frontend
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}

--- a/charts/flagsmith/templates/ingress-sse.yaml
+++ b/charts/flagsmith/templates/ingress-sse.yaml
@@ -12,7 +12,7 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "flagsmith.namespace" . }}
   name: {{ $fullName }}-sse
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}

--- a/charts/flagsmith/templates/jobs-migrate-analytics-data.yaml
+++ b/charts/flagsmith/templates/jobs-migrate-analytics-data.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "flagsmith.namespace" . }}
   name: {{ template "flagsmith.fullname" . }}-migrate-analytics-data-{{ .Release.Revision }}-{{ randAlphaNum 5 | lower }}
   {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}

--- a/charts/flagsmith/templates/jobs-migrate-db.yaml
+++ b/charts/flagsmith/templates/jobs-migrate-db.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "flagsmith.namespace" . }}
   name: {{ template "flagsmith.fullname" . }}-migrate-db-{{ .Release.Revision }}-{{ randAlphaNum 5 | lower }}
   {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}

--- a/charts/flagsmith/templates/routes-api.yaml
+++ b/charts/flagsmith/templates/routes-api.yaml
@@ -3,7 +3,7 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "flagsmith.namespace" . }}
   name: flagsmith-api
   {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}

--- a/charts/flagsmith/templates/routes-frontend.yaml
+++ b/charts/flagsmith/templates/routes-frontend.yaml
@@ -3,7 +3,7 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "flagsmith.namespace" . }}
   name: flagsmith-frontend
   {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}

--- a/charts/flagsmith/templates/secrets-api.yaml
+++ b/charts/flagsmith/templates/secrets-api.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "flagsmith.namespace" . }}
   name: {{ template "flagsmith.fullname" . }}
   {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}

--- a/charts/flagsmith/templates/secrets-influxdb-external.yaml
+++ b/charts/flagsmith/templates/secrets-influxdb-external.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "flagsmith.namespace" . }}
   {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}
   annotations:

--- a/charts/flagsmith/templates/secrets-pgbouncer.yaml
+++ b/charts/flagsmith/templates/secrets-pgbouncer.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "flagsmith.namespace" . }}
   name: {{ template "flagsmith.fullname" . }}-pgbouncer
   {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}

--- a/charts/flagsmith/templates/service-api.yaml
+++ b/charts/flagsmith/templates/service-api.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "flagsmith.namespace" . }}
   name: {{ include "flagsmith.fullname" . }}-api
   {{- $annotations := include "flagsmith.annotations" ( dict "customAnnotations" .Values.service.api.annotations "commonValues" .Values.common ) }}
   {{- with $annotations }}

--- a/charts/flagsmith/templates/service-frontend.yaml
+++ b/charts/flagsmith/templates/service-frontend.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "flagsmith.namespace" . }}
   name: {{ include "flagsmith.fullname" . }}-frontend
   {{- $annotations := include "flagsmith.annotations" ( dict "customAnnotations" .Values.service.frontend.annotations "commonValues" .Values.common ) }}
   {{- with $annotations }}

--- a/charts/flagsmith/templates/service-pgbouncer.yaml
+++ b/charts/flagsmith/templates/service-pgbouncer.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "flagsmith.namespace" . }}
   name: {{ template "flagsmith.fullname" . }}-pgbouncer
   {{- $annotations := include "flagsmith.annotations" .Values.common }}
   {{- with $annotations }}

--- a/charts/flagsmith/templates/service-sse.yaml
+++ b/charts/flagsmith/templates/service-sse.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "flagsmith.namespace" . }}
   name: {{ include "flagsmith.fullname" . }}-sse
   {{- $annotations := include "flagsmith.annotations" ( dict "customAnnotations" .Values.service.sse.annotations "commonValues" .Values.common ) }}
   {{- with $annotations }}

--- a/charts/flagsmith/templates/service-task-processor.yaml
+++ b/charts/flagsmith/templates/service-task-processor.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "flagsmith.namespace" . }}
   name: {{ include "flagsmith.fullname" . }}-task-processor
   {{- $annotations := include "flagsmith.annotations" ( dict "customAnnotations" .Values.service.taskProcessor.annotations "commonValues" .Values.common ) }}
   {{- with $annotations }}

--- a/charts/flagsmith/templates/servicemonitor.yaml
+++ b/charts/flagsmith/templates/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "flagsmith.namespace" . }}
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
     {{- with .Values.serviceMonitor.labels }}
@@ -52,5 +52,5 @@ spec:
       - { key: app.kubernetes.io/component, operator: In, values: [ api, task-processor ] }
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "flagsmith.namespace" . }}
 {{- end }}

--- a/charts/flagsmith/templates/sse-secret-init/job.yaml
+++ b/charts/flagsmith/templates/sse-secret-init/job.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "flagsmith.sse.authenticationTokenSecretName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "flagsmith.namespace" . | quote }}
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
     app.kubernetes.io/component: sse-secret-init
@@ -30,7 +30,7 @@ spec:
             - -c
             - |
               SECRET_NAME={{ include "flagsmith.sse.authenticationTokenSecretName" . }}
-              NAMESPACE={{ .Release.Namespace }}
+              NAMESPACE={{ include "flagsmith.namespace" . }}
               echo "Checking for secret $SECRET_NAME in namespace $NAMESPACE"
               # Attempt to get the secret; if it fails (exit code != 0), create it.
               if ! kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" -o name; then

--- a/charts/flagsmith/templates/sse-secret-init/rbac.yaml
+++ b/charts/flagsmith/templates/sse-secret-init/rbac.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "flagsmith.sse.authenticationTokenSecretName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "flagsmith.namespace" . | quote }}
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
   annotations:
@@ -18,7 +18,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "flagsmith.sse.authenticationTokenSecretName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "flagsmith.namespace" . | quote }}
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
   annotations:
@@ -31,5 +31,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "flagsmith.sse.authenticationTokenSecretName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "flagsmith.namespace" . | quote }}
 {{- end }}

--- a/charts/flagsmith/templates/sse-secret-init/serviceaccount.yaml
+++ b/charts/flagsmith/templates/sse-secret-init/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "flagsmith.sse.authenticationTokenSecretName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "flagsmith.namespace" . | quote }}
   labels:
     {{- include "flagsmith.labels" . | nindent 4 }}
   annotations:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Added `namespaceOverride` support to allow deploying Flagsmith to a specific namespace when used as a sub-chart.

Closes #452

- Added `flagsmith.namespace` helper in `_helpers.tpl` that returns `namespaceOverride` if set, otherwise falls back to `.Release.Namespace`
- Updated all resource templates to use `{{ include "flagsmith.namespace" . }}` for the namespace field

## How did you test this code?

1. Added the Flagsmith chart as a dependency in a parent chart:
```yaml
   # Chart.yaml
   dependencies:
     - name: flagsmith
       version: "x.x.x"
       repository: "file://../flagsmith"
```

2. Set the namespace override in the parent chart's values:
```yaml
   # values.yaml
   flagsmith:
     namespaceOverride: "flagsmith-ns"
```

3. Ran `helm template` and verified all Flagsmith resources have `namespace: flagsmith-ns` in their metadata

4. Deployed to minikube and verified all resources are created in the correct namespace and functioning properly

5. Verified default behavior (without `namespaceOverride`) still uses the release namespace