### PR TITLE
feat: Add Prometheus port support for API and task-processor services

### DIFF
--- a/charts/flagsmith/templates/_api_environment.yaml
+++ b/charts/flagsmith/templates/_api_environment.yaml
@@ -1,5 +1,9 @@
 - name: PROMETHEUS_ENABLED
+{{- if .Values.prometheus.enabled }}
   value: 'true'
+{{- else }}
+  value: 'false'
+{{- end }}
 - name: DATABASE_URL
   valueFrom:
     secretKeyRef:

--- a/charts/flagsmith/templates/service-api.yaml
+++ b/charts/flagsmith/templates/service-api.yaml
@@ -18,5 +18,9 @@ spec:
       targetPort: {{ .Values.service.api.port }}
       protocol: TCP
       name: http
+    - port: {{ .Values.prometheus.port }}
+      targetPort: 9100
+      protocol: TCP
+      name: prom
   selector: {{- include "flagsmith.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: api

--- a/charts/flagsmith/templates/service-task-processor.yaml
+++ b/charts/flagsmith/templates/service-task-processor.yaml
@@ -18,5 +18,9 @@ spec:
       targetPort: {{ .Values.service.taskProcessor.port }}
       protocol: TCP
       name: http
+    - port: {{ .Values.prometheus.port }}
+      targetPort: 9100
+      protocol: TCP
+      name: prom
   selector: {{- include "flagsmith.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: task-processor

--- a/charts/flagsmith/templates/servicemonitor.yaml
+++ b/charts/flagsmith/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceMonitor.enabled }}
+{{- if and .Values.serviceMonitor.enabled .Values.prometheus.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -21,7 +21,7 @@ spec:
   targetLabels: {{ . }}
   {{- end }}
   endpoints:
-    - port: http
+    - port: prom
       {{- with .Values.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -29,6 +29,11 @@ serviceMonitor:
   metricRelabelings: []
   relabelings: []
 
+# Prometheus configuration applies to api and task-processor deployments.
+prometheus:
+  enabled: true
+  port: 9100
+
 api:
   image:
     repository: flagsmith.docker.scarf.sh/flagsmith/flagsmith-api


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

This fixes Prometheus support as the metrics endpoint is published on a dedicated port since 2.211.0.

## How did you test this code?

Deployed locally.