### PR TITLE
fix: Use nindent for imagePullSecrets in migrate-db job template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ charts/*/charts
 .direnv
 .idea/
 .venv/
+.claude/

--- a/charts/flagsmith/ci/migratedb-job-test-values.yaml
+++ b/charts/flagsmith/ci/migratedb-job-test-values.yaml
@@ -1,0 +1,6 @@
+api:
+  enableMigrateDbInitContainer: false
+
+jobs:
+  migrateDb:
+    enabled: true

--- a/charts/flagsmith/templates/jobs-migrate-db.yaml
+++ b/charts/flagsmith/templates/jobs-migrate-db.yaml
@@ -45,7 +45,7 @@ spec:
       {{- end }}
       {{- with .Values.api.image.imagePullSecrets | default .Values.global.image.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
         {{- $securityContext := .Values.jobs.migrateDb.podSecurityContext | default (dict) | deepCopy }}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Fix YAML parse error in `jobs-migrate-db.yaml` caused by `{{- toYaml . | indent 8 }}` on the `imagePullSecrets`      block. The `{{-` trims the preceding newline, and `indent` doesn't add one back, producing invalid YAML. Replaced      with `nindent` which prepends a newline

## How did you test this code?

`helm template --show-only templates/jobs-migrate-db.yaml` renders valid YAML with `imagePullSecrets` set