### PR TITLE
feat: add command and args overrides for API and task processor

### DIFF
--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -125,10 +125,17 @@ spec:
       - name: {{ .Chart.Name }}-api
         image: {{ printf "%s:%s" ( .Values.api.image.repository  ) ( .Values.api.image.tag  | default .Chart.AppVersion ) }}
         imagePullPolicy: {{ .Values.api.image.imagePullPolicy | default .Values.global.image.imagePullPolicy }}
+        {{- if .Values.api.command }}
+        command: {{ toYaml .Values.api.command | nindent 10 }}
+        {{- end }}
+        {{- if .Values.api.args }}
+        args: {{ toYaml .Values.api.args | nindent 10 }}
+        {{- else if not .Values.api.command }}
         {{- if .Values.api.enableMigrateAndServe }}
         args: ["migrate-and-serve"]
         {{- else }}
         args: ["serve"]
+        {{- end }}
         {{- end }}
         ports:
         - containerPort: {{ .Values.service.api.port }}

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -77,10 +77,18 @@ spec:
       - name: {{ .Chart.Name }}-task-processor
         image: {{ .Values.taskProcessor.image.repository | default .Values.api.image.repository }}:{{ .Values.taskProcessor.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.taskProcessor.image.imagePullPolicy | default .Values.api.image.imagePullPolicy | default .Values.global.image.imagePullPolicy }}
+        {{- if .Values.taskProcessor.command }}
+        command: {{ toYaml .Values.taskProcessor.command | nindent 10 }}
+        {{- else }}
         command:
           - ./scripts/run-docker.sh
+        {{- end }}
+        {{- if .Values.taskProcessor.args }}
+        args: {{ toYaml .Values.taskProcessor.args | nindent 10 }}
+        {{- else if not .Values.taskProcessor.command }}
         args:
           - run-task-processor
+        {{- end }}
         ports:
         - containerPort: {{ .Values.service.taskProcessor.port }}
         env: {{ include (print $.Template.BasePath "/_task_processor_environment.yaml") . | nindent 8 }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -109,6 +109,8 @@ api:
     prefix: flagsmith.api
   influxdbSetup:
     enabled: false
+  command: []
+  args: []
   extraInitContainers: []
   extraContainers: []
   extraVolumes: []
@@ -196,6 +198,9 @@ taskProcessor:
     tag: "" # defaults to .Chart.AppVersion
     imagePullPolicy: ""
     imagePullSecrets: []
+
+  command: []
+  args: []
 
   enabled: false
   replicacount: 1


### PR DESCRIPTION
## Summary
- Add `command` and `args` override fields to both API and task processor deployments
- Default args are skipped when a custom command is provided, preventing nonsensical argument injection (e.g., `args: ["serve"]` leaking into a custom entrypoint)
- Follows the existing pattern used in `jobs.migrateDb`