### PR TITLE
feat: Add lifecycle hooks, `terminationGracePeriodSeconds`

### DIFF
--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -71,6 +71,9 @@ spec:
         {{- $securityContext = $securityContext | merge (omit .Values.api.defaultPodSecurityContext "enabled") }}
         {{- end }}
         {{- toYaml $securityContext | nindent 8 }}
+      {{- if .Values.api.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.api.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- if .Values.api.serviceAccountName }}
       serviceAccountName: {{ .Values.api.serviceAccountName }}
       {{- end }}
@@ -168,6 +171,10 @@ spec:
           periodSeconds: {{ .Values.api.readinessProbe.periodSeconds }}
           successThreshold: {{ .Values.api.readinessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.api.readinessProbe.timeoutSeconds }}
+        {{- with .Values.api.lifecycle }}
+        lifecycle:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         resources:
 {{ toYaml .Values.api.resources | indent 10 }}
         volumeMounts: {{ toYaml .Values.api.volumeMounts | nindent 10 }}

--- a/charts/flagsmith/templates/deployment-frontend.yaml
+++ b/charts/flagsmith/templates/deployment-frontend.yaml
@@ -65,6 +65,9 @@ spec:
         {{- $securityContext = $securityContext | merge (omit .Values.frontend.defaultPodSecurityContext "enabled") }}
         {{- end }}
         {{- toYaml $securityContext | nindent 8 }}
+      {{- if .Values.frontend.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.frontend.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- if .Values.frontend.serviceAccountName }}
       serviceAccountName: {{ .Values.frontend.serviceAccountName }}
       {{- end }}
@@ -99,6 +102,10 @@ spec:
           periodSeconds: {{ .Values.frontend.readinessProbe.periodSeconds }}
           successThreshold: {{ .Values.frontend.readinessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.frontend.readinessProbe.timeoutSeconds }}
+        {{- with .Values.frontend.lifecycle }}
+        lifecycle:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         resources:
 {{ toYaml .Values.frontend.resources | indent 10 }}
         volumeMounts:

--- a/charts/flagsmith/templates/deployment-sse.yaml
+++ b/charts/flagsmith/templates/deployment-sse.yaml
@@ -62,6 +62,9 @@ spec:
         {{- $securityContext = $securityContext | merge (omit .Values.sse.defaultPodSecurityContext "enabled") }}
         {{- end }}
         {{- toYaml $securityContext | nindent 8 }}
+      {{- if .Values.sse.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.sse.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- if .Values.sse.serviceAccountName }}
       serviceAccountName: {{ .Values.sse.serviceAccountName }}
       {{- end }}
@@ -97,6 +100,10 @@ spec:
           periodSeconds: {{ .Values.sse.readinessProbe.periodSeconds }}
           successThreshold: {{ .Values.sse.readinessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.sse.readinessProbe.timeoutSeconds }}
+        {{- with .Values.sse.lifecycle }}
+        lifecycle:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         resources:
 {{ toYaml .Values.sse.resources | indent 10 }}
         volumeMounts:

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -66,6 +66,9 @@ spec:
         {{- $securityContext = $securityContext | merge (omit .Values.taskProcessor.defaultPodSecurityContext "enabled") }}
         {{- end }}
         {{- toYaml $securityContext | nindent 8 }}
+      {{- if .Values.taskProcessor.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.taskProcessor.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- if .Values.taskProcessor.serviceAccountName }}
       serviceAccountName: {{ .Values.taskProcessor.serviceAccountName }}
       {{- end }}
@@ -122,6 +125,10 @@ spec:
           periodSeconds: {{ .Values.taskProcessor.readinessProbe.periodSeconds }}
           successThreshold: {{ .Values.taskProcessor.readinessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.taskProcessor.readinessProbe.timeoutSeconds }}
+        {{- with .Values.taskProcessor.lifecycle }}
+        lifecycle:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         resources:
 {{ toYaml .Values.taskProcessor.resources | indent 10 }}
         volumeMounts:

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -74,6 +74,10 @@ api:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # Container lifecycle hooks (e.g. preStop for graceful shutdown)
+  lifecycle: {}
+  # Pod termination grace period in seconds
+  terminationGracePeriodSeconds: null
   podSecurityContext: {}
   defaultPodSecurityContext:
     enabled: true
@@ -164,6 +168,10 @@ frontend:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # Container lifecycle hooks (e.g. preStop for graceful shutdown)
+  lifecycle: {}
+  # Pod termination grace period in seconds
+  terminationGracePeriodSeconds: null
   podSecurityContext: {}
   defaultPodSecurityContext:
     enabled: true
@@ -242,6 +250,10 @@ taskProcessor:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # Container lifecycle hooks (e.g. preStop for graceful shutdown)
+  lifecycle: {}
+  # Pod termination grace period in seconds
+  terminationGracePeriodSeconds: null
   podSecurityContext: {}
   defaultPodSecurityContext:
     enabled: true
@@ -299,6 +311,10 @@ pgbouncer:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # Container lifecycle hooks (e.g. preStop for graceful shutdown)
+  lifecycle: {}
+  # Pod termination grace period in seconds
+  terminationGracePeriodSeconds: null
   podSecurityContext: {}
   defaultPodSecurityContext:
     enabled: true


### PR DESCRIPTION
## Summary

Adds support for container `lifecycle` hooks and pod `terminationGracePeriodSeconds` to all 4 application deployment templates: API, TaskProcessor, Frontend, and SSE.

Currently the PgBouncer deployment template has a hardcoded `preStop` lifecycle hook, but none of the application deployments support configuring lifecycle hooks or termination grace periods via values.

Closes #507

## Changes

- **`templates/deployment-api.yaml`**: Add `lifecycle` and `terminationGracePeriodSeconds`
- **`templates/deployment-task-processor.yaml`**: Add `lifecycle` and `terminationGracePeriodSeconds`
- **`templates/deployment-frontend.yaml`**: Add `lifecycle` and `terminationGracePeriodSeconds`
- **`templates/deployment-sse.yaml`**: Add `lifecycle` and `terminationGracePeriodSeconds`
- **`values.yaml`**: Add default values (`lifecycle: {}`, `terminationGracePeriodSeconds: null`) for all 4 components

## Usage Example

```yaml
api:
  terminationGracePeriodSeconds: 30
  lifecycle:
    preStop:
      exec:
        command: ["/bin/sh", "-c", "sleep 10"]
```

## Backward Compatibility

- Defaults are `lifecycle: {}` and `terminationGracePeriodSeconds: null`, which means no change to existing deployments
- Both fields are rendered conditionally (`{{- with }}` / `{{- if }}`) so they are omitted entirely when not set

## Testing

Verified with `helm template` that:
- All 4 templates render `lifecycle` and `terminationGracePeriodSeconds` correctly when set
- Default values produce no change in rendered output (no lifecycle or terminationGracePeriodSeconds in the manifest)