### PR TITLE
feat(pgbouncer): Support existing secret for PgBouncer credentials

### DIFF
--- a/charts/flagsmith/templates/_helpers.tpl
+++ b/charts/flagsmith/templates/_helpers.tpl
@@ -203,8 +203,8 @@ PgBouncer hostname
 PgBouncer secret name
 */}}
 {{- define "flagsmith.pgbouncer.secretName" -}}
-{{- if .Values.pgbouncer.existingSecret -}}
-{{- .Values.pgbouncer.existingSecret -}}
+{{- if .Values.pgbouncer.credentialsFromExistingSecret.enabled -}}
+{{- .Values.pgbouncer.credentialsFromExistingSecret.name -}}
 {{- else -}}
 {{- template "flagsmith.fullname" . }}-pgbouncer
 {{- end -}}

--- a/charts/flagsmith/templates/_helpers.tpl
+++ b/charts/flagsmith/templates/_helpers.tpl
@@ -200,6 +200,17 @@ PgBouncer hostname
 {{- end -}}
 
 {{/*
+PgBouncer secret name
+*/}}
+{{- define "flagsmith.pgbouncer.secretName" -}}
+{{- if .Values.pgbouncer.existingSecret -}}
+{{- .Values.pgbouncer.existingSecret -}}
+{{- else -}}
+{{- template "flagsmith.fullname" . }}-pgbouncer
+{{- end -}}
+{{- end -}}
+
+{{/*
 Expand the name of the chart.
 */}}
 {{- define "flagsmith.influxdb.name" -}}

--- a/charts/flagsmith/templates/deployment-pgbouncer.yaml
+++ b/charts/flagsmith/templates/deployment-pgbouncer.yaml
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if not .Values.pgbouncer.existingSecret }}
+        {{- if not .Values.pgbouncer.credentialsFromExistingSecret.enabled }}
         checksum/secrets-pgbouncer: {{ include (print $.Template.BasePath "/secrets-pgbouncer.yaml") . | sha256sum }}
         {{- end }}
 {{- if .Values.pgbouncer.podAnnotations }}

--- a/charts/flagsmith/templates/deployment-pgbouncer.yaml
+++ b/charts/flagsmith/templates/deployment-pgbouncer.yaml
@@ -24,7 +24,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- if not .Values.pgbouncer.existingSecret }}
         checksum/secrets-pgbouncer: {{ include (print $.Template.BasePath "/secrets-pgbouncer.yaml") . | sha256sum }}
+        {{- end }}
 {{- if .Values.pgbouncer.podAnnotations }}
 {{ toYaml .Values.pgbouncer.podAnnotations | nindent 8 }}
 {{- end }}
@@ -83,28 +85,28 @@ spec:
         - name: POSTGRESQL_HOST
           valueFrom:
             secretKeyRef:
-              name: {{ template "flagsmith.fullname" . }}-pgbouncer
+              name: {{ include "flagsmith.pgbouncer.secretName" . }}
               key: POSTGRESQL_HOST
         - name: POSTGRESQL_DATABASE
           valueFrom:
             secretKeyRef:
-              name: {{ template "flagsmith.fullname" . }}-pgbouncer
+              name: {{ include "flagsmith.pgbouncer.secretName" . }}
               key: POSTGRESQL_DATABASE
         # Expose the database with its actual name
         - name: PGBOUNCER_DATABASE
           valueFrom:
             secretKeyRef:
-              name: {{ template "flagsmith.fullname" . }}-pgbouncer
+              name: {{ include "flagsmith.pgbouncer.secretName" . }}
               key: POSTGRESQL_DATABASE
         - name: POSTGRESQL_USERNAME
           valueFrom:
             secretKeyRef:
-              name: {{ template "flagsmith.fullname" . }}-pgbouncer
+              name: {{ include "flagsmith.pgbouncer.secretName" . }}
               key: POSTGRESQL_USER
         - name: POSTGRESQL_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "flagsmith.fullname" . }}-pgbouncer
+              name: {{ include "flagsmith.pgbouncer.secretName" . }}
               key: POSTGRESQL_PASSWORD
         - name: PGBOUNCER_PORT
           value: '5432'

--- a/charts/flagsmith/templates/secrets-pgbouncer.yaml
+++ b/charts/flagsmith/templates/secrets-pgbouncer.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.pgbouncer.enabled }}
+{{- if and .Values.pgbouncer.enabled (not .Values.pgbouncer.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -15,7 +15,7 @@ metadata:
 type: Opaque
 data:
   {{- if and .Values.databaseExternal.enabled .Values.databaseExternal.urlFromExistingSecret.enabled }}
-  {{- fail "Cannot read URL from existing secret when using PgBouncer. PgBouncer needs host, user and password as separate environment variables." }}
+  {{- fail "Cannot read URL from existing secret when using PgBouncer without pgbouncer.existingSecret. Either set pgbouncer.existingSecret to provide PgBouncer credentials from an existing secret, or provide the database URL directly via databaseExternal.url." }}
   {{- end }}
   {{- $urlParts := (include "flagsmith.api.realDatabaseUrl" . | trim | urlParse) }}
   {{- $userParts := $urlParts.userinfo | split ":" }}

--- a/charts/flagsmith/templates/secrets-pgbouncer.yaml
+++ b/charts/flagsmith/templates/secrets-pgbouncer.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.pgbouncer.enabled (not .Values.pgbouncer.existingSecret) }}
+{{- if and .Values.pgbouncer.enabled (not .Values.pgbouncer.credentialsFromExistingSecret.enabled) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -15,7 +15,7 @@ metadata:
 type: Opaque
 data:
   {{- if and .Values.databaseExternal.enabled .Values.databaseExternal.urlFromExistingSecret.enabled }}
-  {{- fail "Cannot read URL from existing secret when using PgBouncer without pgbouncer.existingSecret. Either set pgbouncer.existingSecret to provide PgBouncer credentials from an existing secret, or provide the database URL directly via databaseExternal.url." }}
+  {{- fail "Cannot read URL from existing secret when using PgBouncer without pgbouncer.credentialsFromExistingSecret. Either set pgbouncer.credentialsFromExistingSecret.enabled and pgbouncer.credentialsFromExistingSecret.name to provide PgBouncer credentials from an existing secret, or provide the database URL directly via databaseExternal.url." }}
   {{- end }}
   {{- $urlParts := (include "flagsmith.api.realDatabaseUrl" . | trim | urlParse) }}
   {{- $userParts := $urlParts.userinfo | split ":" }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -292,6 +292,10 @@ pgbouncer:
   deploymentStrategy: null
   # Optional: Use to override the password directly instead of extracting from the database URL
   passwordOverride: ""
+  # Optional: Use an existing secret for PgBouncer credentials instead of generating one.
+  # The secret must contain keys: POSTGRESQL_HOST, POSTGRESQL_DATABASE, POSTGRESQL_USER, POSTGRESQL_PASSWORD
+  # This allows use of PgBouncer with databaseExternal.urlFromExistingSecret.enabled: true
+  existingSecret: null
   podAnnotations: {}
   resources: {}
   podLabels: {}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -307,7 +307,9 @@ pgbouncer:
   # Optional: Use an existing secret for PgBouncer credentials instead of generating one.
   # The secret must contain keys: POSTGRESQL_HOST, POSTGRESQL_DATABASE, POSTGRESQL_USER, POSTGRESQL_PASSWORD
   # This allows use of PgBouncer with databaseExternal.urlFromExistingSecret.enabled: true
-  existingSecret: null
+  credentialsFromExistingSecret:
+    enabled: false
+    name: ""
   podAnnotations: {}
   resources: {}
   podLabels: {}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

- Add `pgbouncer.existingSecret` option to allow PgBouncer to read credentials from a user-managed Kubernetes secret
- Unblocks using `pgbouncer.enabled: true` with `databaseExternal.urlFromExistingSecret.enabled: true`
- Improve error message to guide users toward the new option when the combination is used without `existingSecret`

## Changes

- **`values.yaml`** — Add `pgbouncer.existingSecret: null` option.
- **`_helpers.tpl`** — Add `flagsmith.pgbouncer.secretName` helper that resolves to either the existing secret or the chart-generated one.
- **`secrets-pgbouncer.yaml`** — Skip secret generation when `existingSecret` is set; improve error message to guide users toward the new option.
- **`deployment-pgbouncer.yaml`** — Use the new helper for all secret references; skip checksum annotation when using an existing secret.


Closes #506 

## How did you test this code?

Verified with `helm template` across three scenarios:

1. **New feature path** — `existingSecret` set with `urlFromExistingSecret`: deployment references the user-provided secret, no pgbouncer secret resource is generated.
2. **Original path** — inline `databaseExternal.url`: chart-generated secret and checksum annotation still work as before.
3. **Guard rail** — `urlFromExistingSecret` without `existingSecret`: fails with an actionable error message.

