### PR TITLE
feat: Add default rules for API, SSE, and frontend HTTPRoutes

### DIFF
--- a/charts/flagsmith/templates/httproute-api.yaml
+++ b/charts/flagsmith/templates/httproute-api.yaml
@@ -23,7 +23,25 @@ spec:
   hostnames:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  # TODO: add default rules for /api/, /health/, /admin/, /static/admin/
   rules:
+  {{- if .Values.gateway.api.rules }}
     {{- toYaml .Values.gateway.api.rules | nindent 4 }}
+  {{- else }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/
+        - path:
+            type: PathPrefix
+            value: /health/
+        - path:
+            type: PathPrefix
+            value: /admin/
+        - path:
+            type: PathPrefix
+            value: /static/admin/
+      backendRefs:
+        - name: {{ $fullName }}-api
+          port: {{ $svcPort }}
+  {{- end }}
 {{- end }}

--- a/charts/flagsmith/templates/httproute-frontend.yaml
+++ b/charts/flagsmith/templates/httproute-frontend.yaml
@@ -31,5 +31,8 @@ spec:
         - path:
             type: PathPrefix
             value: /
+      backendRefs:
+        - name: {{ $fullName }}-frontend
+          port: {{ $svcPort }}
   {{- end }}
 {{- end }}

--- a/charts/flagsmith/templates/httproute-sse.yaml
+++ b/charts/flagsmith/templates/httproute-sse.yaml
@@ -23,7 +23,16 @@ spec:
   hostnames:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  # TODO: add default rule for /
   rules:
+  {{- if .Values.gateway.sse.rules }}
     {{- toYaml .Values.gateway.sse.rules | nindent 4 }}
+  {{- else }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ $fullName }}-sse
+          port: {{ $svcPort }}
+  {{- end }}
 {{- end }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -538,13 +538,13 @@ gateway:
     enabled: false
     parentRefs: []
     hostnames: []
-    # rules defines routing rules. No defaults — must be provided by the user.
+    # rules defines routing rules. If empty, defaults to /api/, /health/, /admin/, /static/admin/ routing to the API service.
     rules: []
   sse:
     enabled: false
     parentRefs: []
     hostnames: []
-    # rules defines routing rules. No defaults — must be provided by the user.
+    # rules defines routing rules. If empty, defaults to "/" routing to the SSE service.
     rules: []
 
 jobs:


### PR DESCRIPTION
Closes #493

## Problem

The Gateway API HTTPRoute templates don't work out of the box — API and SSE have no default routing rules, and the frontend has a path match but no `backendRefs` to actually forward traffic.

## Solution

Add default rules matching the existing Ingress behaviour:

- **API**: routes `/api/`, `/health/`, `/admin/`, `/static/admin/` to the Django backend
- **SSE**: routes `/` to the Server-Sent Events service (real-time flag updates to SDKs). Catch-all is correct because SSE gets its own dedicated hostname.
- **Frontend**: adds the missing `backendRefs` to the existing `/` path match

Custom rules via `gateway.{api,sse,frontend}.rules` still override all defaults.