### PR TITLE
fix(api,task-processor): Close shutdown drain gap and name container ports

### DIFF
--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -126,7 +126,12 @@ spec:
         {{- end }}
         {{- end }}
         ports:
-        - containerPort: {{ .Values.service.api.port }}
+        - name: http
+          containerPort: {{ .Values.service.api.port }}
+        {{- if .Values.prometheus.enabled }}
+        - name: prom
+          containerPort: 9100
+        {{- end }}
         env: {{ include (print $.Template.BasePath "/_api_environment.yaml") . | nindent 8 }}
         livenessProbe:
           {{- if .Values.api.livenessProbe.exec }}

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -93,7 +93,12 @@ spec:
           - run-task-processor
         {{- end }}
         ports:
-        - containerPort: {{ .Values.service.taskProcessor.port }}
+        - name: http
+          containerPort: {{ .Values.service.taskProcessor.port }}
+        {{- if .Values.prometheus.enabled }}
+        - name: prom
+          containerPort: 9100
+        {{- end }}
         env: {{ include (print $.Template.BasePath "/_task_processor_environment.yaml") . | nindent 8 }}
         livenessProbe:
           {{- $exec := .Values.taskProcessor.livenessProbe.exec | default .Values.api.livenessProbe.exec }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -74,10 +74,19 @@ api:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  # Container lifecycle hooks (e.g. preStop for graceful shutdown)
-  lifecycle: {}
-  # Pod termination grace period in seconds
-  terminationGracePeriodSeconds: null
+  # Container lifecycle hooks. Default preStop delays SIGTERM so the
+  # LB / endpoints controller has time to deregister the pod before
+  # gunicorn closes its listen socket. Without this, rolling deploys
+  # and HPA scale-down can cause a short 5xx spike on traffic that
+  # the LB routes to the pod after it has stopped accepting connections.
+  lifecycle:
+    preStop:
+      exec:
+        command: ["sleep", "20"]
+  # Pod termination grace period in seconds. Must exceed the LB's
+  # connection-draining timeout so the kubelet does not SIGKILL
+  # the pod while the LB is still draining in-flight connections.
+  terminationGracePeriodSeconds: 75
   podSecurityContext: {}
   defaultPodSecurityContext:
     enabled: true
@@ -461,7 +470,7 @@ hpa:
     enabled: false
     minReplicas: 2
     maxReplicas: 10
-    targetCPUUtilization: 50 
+    targetCPUUtilization: 50
   sse:
     enabled: true
     minReplicas: 1

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -74,11 +74,12 @@ api:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  # Container lifecycle hooks. Default preStop delays SIGTERM so the
-  # LB / endpoints controller has time to deregister the pod before
-  # gunicorn closes its listen socket. Without this, rolling deploys
-  # and HPA scale-down can cause a short 5xx spike on traffic that
-  # the LB routes to the pod after it has stopped accepting connections.
+  # Container lifecycle hooks. The preStop sleep below ships as the
+  # default so the LB / endpoints controller has time to deregister
+  # the pod before gunicorn closes its listen socket. Without it,
+  # rolling deploys and HPA scale-down can cause a short 5xx spike on
+  # traffic the LB routes to the pod after it stops accepting
+  # connections. Override `lifecycle` to customise.
   lifecycle:
     preStop:
       exec:


### PR DESCRIPTION
Two small, independent fixes to the api and task-processor deployment templates.

#### 1. Close shutdown drain gap

Default `terminationGracePeriodSeconds` to 75 and add `preStop sleep 20` on the API container. Lets the load balancer finish deregistering the pod before gunicorn stops accepting connections, so rolling deploys and HPA scale-downs no longer cause a brief 5xx spike.

#### 2. Name container ports

The api and task-processor container ports were unnamed. PodMonitoring resources that reference them by name (`port: http` or `port: prom`) silently scraped nothing as a result. Adding names fixes that. Existing Service and ServiceMonitor resources are unaffected — they reference ports numerically or via the Service name.

Contributes to Flagsmith/infrastructure#317