### PR TITLE
feat: Expose extraTemplateSpec, fix api extraSpec location

### DIFF
--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -179,6 +179,9 @@ spec:
 {{- with .Values.api.extraVolumes }}
 {{- toYaml . | nindent 6 }}
 {{- end }}
+{{- with .Values.api.extraTemplateSpec }}
+{{- toYaml . | nindent 6 }}
+{{- end }}
 {{- with .Values.api.extraSpec }}
 {{- toYaml . | nindent 2 }}
 {{- end }}

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -175,8 +175,8 @@ spec:
     {{- tpl (toYaml .) $ | nindent 6 }}
 {{- end }}
 {{- end }}
-      volumes:
 {{- with .Values.api.extraVolumes }}
+      volumes:
 {{- toYaml . | nindent 6 }}
 {{- end }}
 {{- with .Values.api.extraTemplateSpec }}

--- a/charts/flagsmith/templates/deployment-frontend.yaml
+++ b/charts/flagsmith/templates/deployment-frontend.yaml
@@ -117,8 +117,8 @@ spec:
     {{- tpl (toYaml .) $ | nindent 6 }}
 {{- end }}
 {{- end }}
-      volumes:
 {{- with .Values.frontend.extraVolumes }}
+      volumes:
 {{- toYaml . | nindent 6 }}
 {{- end }}
 {{- with .Values.frontend.extraTemplateSpec }}

--- a/charts/flagsmith/templates/deployment-frontend.yaml
+++ b/charts/flagsmith/templates/deployment-frontend.yaml
@@ -121,6 +121,9 @@ spec:
 {{- with .Values.frontend.extraVolumes }}
 {{- toYaml . | nindent 6 }}
 {{- end }}
+{{- with .Values.frontend.extraTemplateSpec }}
+{{- toYaml . | nindent 6 }}
+{{- end }}
 {{- with .Values.frontend.extraSpec }}
 {{- toYaml . | nindent 2 }}
 {{- end }}

--- a/charts/flagsmith/templates/deployment-pgbouncer.yaml
+++ b/charts/flagsmith/templates/deployment-pgbouncer.yaml
@@ -156,4 +156,7 @@ spec:
 {{- with .Values.pgbouncer.extraVolumes }}
 {{- toYaml . | nindent 6 }}
 {{- end }}
+{{- with .Values.pgbouncer.extraTemplateSpec }}
+{{- toYaml . | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/charts/flagsmith/templates/deployment-pgbouncer.yaml
+++ b/charts/flagsmith/templates/deployment-pgbouncer.yaml
@@ -152,8 +152,8 @@ spec:
     {{- tpl (toYaml .) $ | nindent 6 }}
 {{- end }}
 {{- end }}
-      volumes:
 {{- with .Values.pgbouncer.extraVolumes }}
+      volumes:
 {{- toYaml . | nindent 6 }}
 {{- end }}
 {{- with .Values.pgbouncer.extraTemplateSpec }}

--- a/charts/flagsmith/templates/deployment-sse.yaml
+++ b/charts/flagsmith/templates/deployment-sse.yaml
@@ -115,8 +115,8 @@ spec:
     {{- tpl (toYaml .) $ | nindent 6 }}
 {{- end }}
 {{- end }}
-      volumes:
 {{- with .Values.sse.extraVolumes }}
+      volumes:
 {{- toYaml . | nindent 6 }}
 {{- end }}
 {{- with .Values.sse.extraTemplateSpec }}

--- a/charts/flagsmith/templates/deployment-sse.yaml
+++ b/charts/flagsmith/templates/deployment-sse.yaml
@@ -119,6 +119,9 @@ spec:
 {{- with .Values.sse.extraVolumes }}
 {{- toYaml . | nindent 6 }}
 {{- end }}
+{{- with .Values.sse.extraTemplateSpec }}
+{{- toYaml . | nindent 6 }}
+{{- end }}
 {{- with .Values.sse.extraSpec }}
 {{- toYaml . | nindent 2 }}
 {{- end }}

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -149,6 +149,9 @@ spec:
 {{- with .Values.taskProcessor.extraVolumes }}
 {{- toYaml . | nindent 6 }}
 {{- end }}
+{{- with .Values.taskProcessor.extraTemplateSpec }}
+{{- toYaml . | nindent 6 }}
+{{- end }}
 {{- with .Values.taskProcessor.extraSpec }}
 {{- toYaml . | nindent 2 }}
 {{- end }}

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -145,8 +145,8 @@ spec:
     {{- tpl (toYaml .) $ | nindent 6 }}
 {{- end }}
 {{- end }}
-      volumes:
 {{- with .Values.taskProcessor.extraVolumes }}
+      volumes:
 {{- toYaml . | nindent 6 }}
 {{- end }}
 {{- with .Values.taskProcessor.extraTemplateSpec }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -138,7 +138,8 @@ api:
     adminEmail: null
     organisationName: null
     projectName: null
-    extraSpec: {} # Will be added to `spec` for `flagsmith-api` deployment.
+
+  extraSpec: {} # Will be added to `spec` for `flagsmith-api` deployment.
   extraTemplateSpec: {} # Will be added to `spec.template.spec` for `flagsmith-api` deployment.
 
   # secretKeyFromExistingSecret points to the Secret that contains the Django secret key. If none is provided, a Job

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -139,6 +139,7 @@ api:
     organisationName: null
     projectName: null
     extraSpec: {} # Will be added to `spec` for `flagsmith-api` deployment.
+  extraTemplateSpec: {} # Will be added to `spec.template.spec` for `flagsmith-api` deployment.
 
   # secretKeyFromExistingSecret points to the Secret that contains the Django secret key. If none is provided, a Job
   # will be created to generate one.
@@ -203,6 +204,7 @@ frontend:
   extraVolumes: []
   volumeMounts: []
   extraSpec: {} # Will be added to `spec` for `flagsmith-frontend` deployment.
+  extraTemplateSpec: {} # Will be added to `spec.template.spec` for `flagsmith-frontend` deployment.
 
 # See https://docs.flagsmith.com/deployment/task-processor
 taskProcessor:
@@ -274,6 +276,7 @@ taskProcessor:
   extraVolumes: []
   volumeMounts: []
   extraSpec: {} # Will be added to `spec` for `flagsmith-task-processor` deployment.
+  extraTemplateSpec: {} # Will be added to `spec.template.spec` for `flagsmith-task-processor` deployment.
 
 devPostgresql:
   image:
@@ -357,6 +360,7 @@ pgbouncer:
   extraContainers: []
   extraVolumes: []
   volumeMounts: []
+  extraTemplateSpec: {} # Will be added to `spec.template.spec` for `flagsmith-pgbouncer` deployment.
 
 influxdbExternal:
   enabled: false
@@ -442,6 +446,7 @@ sse:
   extraContainers: []
   extraVolumes: []
   volumeMounts: []
+  extraTemplateSpec: {} # Will be added to `spec.template.spec` for `flagsmith-sse` deployment.
 
 service:
   api:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Add `extraTemplateSpec` to be added to `spec.template.spec` in 5 templates. Allows specifying additional fields like `priorityClassName`. Addresses #446 
1. deployment-api.yaml
2. deployment-frontend.yaml
3. deployment-pgbouncer.yaml
4. deployment-sse.yaml
5. deployment-task-processor.yaml

In `values.yaml` move `extraSpec` outside of `bootstrap` and directly under `api`. Template reads from `.Values.api.extraSpec`, not `.Values.api.bootsrap.extraSpec`.

## How did you test this code?

1. Compare baseline
```
helm template flagsmith ./charts/flagsmith > /tmp/default.yaml
helm template flagsmith ./charts/flagsmith > /tmp/baseline.yaml
diff /tmp/baseline.yaml /tmp/default.yaml
```

2. priorityClassName renders at correct YAML level
```
helm template flagsmith ./charts/flagsmith \
  --set api.extraTemplateSpec.priorityClassName=high-priority \
  --show-only templates/deployment-api.yaml \
  | yq '.spec.template.spec.priorityClassName'
```

3. Verify arbitrary field renders
```
helm template flagsmith ./charts/flagsmith \
  --set api.extraTemplateSpec.runtimeClassName=gvisor \
  --set api.extraTemplateSpec.hostNetwork=false \
  --show-only templates/deployment-api.yaml \
  | yq '.spec.template.spec'
```

4. Verify all 5 deployments
```
for tpl in deployment-api deployment-frontend deployment-task-processor deployment-sse deployment-pgbouncer; do
  case $tpl in
    deployment-frontend)     extra="--set api.separateApiAndFrontend=true --set frontend.enabled=true --set frontend.extraTemplateSpec.priorityClassName=test" ;;
    deployment-task-processor) extra="--set taskProcessor.enabled=true --set taskProcessor.extraTemplateSpec.priorityClassName=test" ;;
    deployment-sse)          extra="--set sse.enabled=true --set sse.extraTemplateSpec.priorityClassName=test" ;;
    deployment-pgbouncer)    extra="--set pgbouncer.enabled=true --set pgbouncer.extraTemplateSpec.priorityClassName=test" ;;
    deployment-api)          extra="--set api.extraTemplateSpec.priorityClassName=test" ;;
  esac
                                                                                                                                                                  
  result=$(eval helm template flagsmith ./charts/flagsmith $extra \
    --show-only templates/${tpl}.yaml 2>&1 \
    | yq '.spec.template.spec.priorityClassName')
                                                                                                                                                                  
  echo "$tpl: $result"
done
```

5.  Verify `api.extraSpec` fix
```
helm template flagsmith ./charts/flagsmith \
  --set api.extraSpec.strategy.type=Recreate \
  --show-only templates/deployment-api.yaml \
  | yq '.spec.strategy.type'
```

6 Verify `volumes:` included only if `extraVolumes` is specified.
```
helm template flagsmith ./charts/flagsmith \
    --show-only templates/deployment-api.yaml 2>&1 | yq '.spec.template.spec.volumes'

helm template flagsmith ./charts/flagsmith \
    --set 'api.extraVolumes[0].name=test-vol' \
    --set 'api.extraVolumes[0].emptyDir.medium=Memory' \
    --show-only templates/deployment-api.yaml 2>&1 | yq '.spec.template.spec.volumes'

# etc for other charts.
```