### PR TITLE
feat: expose container-level securityContext for api, frontend, taskProcessor, sse, and migrate jobs

### DIFF
--- a/charts/flagsmith/templates/_helpers.tpl
+++ b/charts/flagsmith/templates/_helpers.tpl
@@ -364,3 +364,17 @@ key: {{ default "django-secret-key" .Values.api.secretKeyFromExistingSecret.key 
 name: {{ include "flagsmith.sse.authenticationTokenSecretName" . }}
 key: {{ default "sse-authentication-token" .Values.sse.authenticationTokenFromExistingSecret.key }}
 {{- end }}
+
+{{/*
+Security context: chart defaults with user values merged on top (user wins).
+Usage: (dict "component" .Values.api "key" "securityContext"|"podSecurityContext")
+*/}}
+{{- define "flagsmith.mergedSecurityContext" -}}
+{{- $defaultKey := printf "default%s" (.key | title) -}}
+{{- $ctx := index .component .key | default dict | deepCopy -}}
+{{- $defaults := index .component $defaultKey | default dict -}}
+{{- if $defaults.enabled -}}
+{{- $ctx = $ctx | merge (omit $defaults "enabled") -}}
+{{- end -}}
+{{- toYaml $ctx -}}
+{{- end -}}

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -62,12 +62,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      securityContext:
-        {{- $securityContext := .Values.api.podSecurityContext | default (dict) | deepCopy }}
-        {{- if .Values.api.defaultPodSecurityContext.enabled }}
-        {{- $securityContext = $securityContext | merge (omit .Values.api.defaultPodSecurityContext "enabled") }}
-        {{- end }}
-        {{- toYaml $securityContext | nindent 8 }}
+      securityContext: {{- include "flagsmith.mergedSecurityContext" (dict "component" .Values.api "key" "podSecurityContext") | nindent 8 }}
       {{- if .Values.api.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.api.terminationGracePeriodSeconds }}
       {{- end }}
@@ -81,12 +76,7 @@ spec:
         imagePullPolicy: {{ .Values.api.image.imagePullPolicy | default .Values.global.image.imagePullPolicy }}
         args: ["migrate"]
         env: {{ include (print $.Template.BasePath "/_api_environment.yaml") . | nindent 8 }}
-        securityContext:
-          {{- $securityContext := .Values.api.securityContext | default (dict) | deepCopy }}
-          {{- if .Values.api.defaultSecurityContext.enabled }}
-          {{- $securityContext = $securityContext | merge (omit .Values.api.defaultSecurityContext "enabled") }}
-          {{- end }}
-          {{- toYaml $securityContext | nindent 10 }}
+        securityContext: {{- include "flagsmith.mergedSecurityContext" (dict "component" .Values.api "key" "securityContext") | nindent 10 }}
         volumeMounts: {{ toYaml .Values.api.volumeMounts | nindent 10 }}
 {{- end }}
 {{- if .Values.api.bootstrap.enabled }}
@@ -110,12 +100,7 @@ spec:
         - name: PROJECT_NAME
           value: {{ .Values.api.bootstrap.projectName }}
         {{- end }}
-        securityContext:
-          {{- $securityContext := .Values.api.securityContext | default (dict) | deepCopy }}
-          {{- if .Values.api.defaultSecurityContext.enabled }}
-          {{- $securityContext = $securityContext | merge (omit .Values.api.defaultSecurityContext "enabled") }}
-          {{- end }}
-          {{- toYaml $securityContext | nindent 10 }}
+        securityContext: {{- include "flagsmith.mergedSecurityContext" (dict "component" .Values.api "key" "securityContext") | nindent 10 }}
         volumeMounts: {{ toYaml .Values.api.volumeMounts | nindent 10 }}
 {{- end }}
 {{- with .Values.api.extraInitContainers }}
@@ -177,12 +162,7 @@ spec:
         lifecycle:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        securityContext:
-          {{- $securityContext := .Values.api.securityContext | default (dict) | deepCopy }}
-          {{- if .Values.api.defaultSecurityContext.enabled }}
-          {{- $securityContext = $securityContext | merge (omit .Values.api.defaultSecurityContext "enabled") }}
-          {{- end }}
-          {{- toYaml $securityContext | nindent 10 }}
+        securityContext: {{- include "flagsmith.mergedSecurityContext" (dict "component" .Values.api "key" "securityContext") | nindent 10 }}
         resources:
 {{ toYaml .Values.api.resources | indent 10 }}
         volumeMounts: {{ toYaml .Values.api.volumeMounts | nindent 10 }}

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -81,6 +81,12 @@ spec:
         imagePullPolicy: {{ .Values.api.image.imagePullPolicy | default .Values.global.image.imagePullPolicy }}
         args: ["migrate"]
         env: {{ include (print $.Template.BasePath "/_api_environment.yaml") . | nindent 8 }}
+        securityContext:
+          {{- $securityContext := .Values.api.securityContext | default (dict) | deepCopy }}
+          {{- if .Values.api.defaultSecurityContext.enabled }}
+          {{- $securityContext = $securityContext | merge (omit .Values.api.defaultSecurityContext "enabled") }}
+          {{- end }}
+          {{- toYaml $securityContext | nindent 10 }}
         volumeMounts: {{ toYaml .Values.api.volumeMounts | nindent 10 }}
 {{- end }}
 {{- if .Values.api.bootstrap.enabled }}
@@ -104,6 +110,12 @@ spec:
         - name: PROJECT_NAME
           value: {{ .Values.api.bootstrap.projectName }}
         {{- end }}
+        securityContext:
+          {{- $securityContext := .Values.api.securityContext | default (dict) | deepCopy }}
+          {{- if .Values.api.defaultSecurityContext.enabled }}
+          {{- $securityContext = $securityContext | merge (omit .Values.api.defaultSecurityContext "enabled") }}
+          {{- end }}
+          {{- toYaml $securityContext | nindent 10 }}
         volumeMounts: {{ toYaml .Values.api.volumeMounts | nindent 10 }}
 {{- end }}
 {{- with .Values.api.extraInitContainers }}
@@ -165,6 +177,12 @@ spec:
         lifecycle:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        securityContext:
+          {{- $securityContext := .Values.api.securityContext | default (dict) | deepCopy }}
+          {{- if .Values.api.defaultSecurityContext.enabled }}
+          {{- $securityContext = $securityContext | merge (omit .Values.api.defaultSecurityContext "enabled") }}
+          {{- end }}
+          {{- toYaml $securityContext | nindent 10 }}
         resources:
 {{ toYaml .Values.api.resources | indent 10 }}
         volumeMounts: {{ toYaml .Values.api.volumeMounts | nindent 10 }}

--- a/charts/flagsmith/templates/deployment-frontend.yaml
+++ b/charts/flagsmith/templates/deployment-frontend.yaml
@@ -59,12 +59,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      securityContext:
-        {{- $securityContext := .Values.frontend.podSecurityContext | default (dict) | deepCopy }}
-        {{- if .Values.frontend.defaultPodSecurityContext.enabled }}
-        {{- $securityContext = $securityContext | merge (omit .Values.frontend.defaultPodSecurityContext "enabled") }}
-        {{- end }}
-        {{- toYaml $securityContext | nindent 8 }}
+      securityContext: {{- include "flagsmith.mergedSecurityContext" (dict "component" .Values.frontend "key" "podSecurityContext") | nindent 8 }}
       {{- if .Values.frontend.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.frontend.terminationGracePeriodSeconds }}
       {{- end }}
@@ -106,12 +101,7 @@ spec:
         lifecycle:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        securityContext:
-          {{- $securityContext := .Values.frontend.securityContext | default (dict) | deepCopy }}
-          {{- if .Values.frontend.defaultSecurityContext.enabled }}
-          {{- $securityContext = $securityContext | merge (omit .Values.frontend.defaultSecurityContext "enabled") }}
-          {{- end }}
-          {{- toYaml $securityContext | nindent 10 }}
+        securityContext: {{- include "flagsmith.mergedSecurityContext" (dict "component" .Values.frontend "key" "securityContext") | nindent 10 }}
         resources:
 {{ toYaml .Values.frontend.resources | indent 10 }}
         volumeMounts:

--- a/charts/flagsmith/templates/deployment-frontend.yaml
+++ b/charts/flagsmith/templates/deployment-frontend.yaml
@@ -106,6 +106,12 @@ spec:
         lifecycle:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        securityContext:
+          {{- $securityContext := .Values.frontend.securityContext | default (dict) | deepCopy }}
+          {{- if .Values.frontend.defaultSecurityContext.enabled }}
+          {{- $securityContext = $securityContext | merge (omit .Values.frontend.defaultSecurityContext "enabled") }}
+          {{- end }}
+          {{- toYaml $securityContext | nindent 10 }}
         resources:
 {{ toYaml .Values.frontend.resources | indent 10 }}
         volumeMounts:

--- a/charts/flagsmith/templates/deployment-sse.yaml
+++ b/charts/flagsmith/templates/deployment-sse.yaml
@@ -104,6 +104,12 @@ spec:
         lifecycle:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        securityContext:
+          {{- $securityContext := .Values.sse.securityContext | default (dict) | deepCopy }}
+          {{- if .Values.sse.defaultSecurityContext.enabled }}
+          {{- $securityContext = $securityContext | merge (omit .Values.sse.defaultSecurityContext "enabled") }}
+          {{- end }}
+          {{- toYaml $securityContext | nindent 10 }}
         resources:
 {{ toYaml .Values.sse.resources | indent 10 }}
         volumeMounts:

--- a/charts/flagsmith/templates/deployment-sse.yaml
+++ b/charts/flagsmith/templates/deployment-sse.yaml
@@ -56,12 +56,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      securityContext:
-        {{- $securityContext := .Values.sse.podSecurityContext | default (dict) | deepCopy }}
-        {{- if .Values.sse.defaultPodSecurityContext.enabled }}
-        {{- $securityContext = $securityContext | merge (omit .Values.sse.defaultPodSecurityContext "enabled") }}
-        {{- end }}
-        {{- toYaml $securityContext | nindent 8 }}
+      securityContext: {{- include "flagsmith.mergedSecurityContext" (dict "component" .Values.sse "key" "podSecurityContext") | nindent 8 }}
       {{- if .Values.sse.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.sse.terminationGracePeriodSeconds }}
       {{- end }}
@@ -104,12 +99,7 @@ spec:
         lifecycle:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        securityContext:
-          {{- $securityContext := .Values.sse.securityContext | default (dict) | deepCopy }}
-          {{- if .Values.sse.defaultSecurityContext.enabled }}
-          {{- $securityContext = $securityContext | merge (omit .Values.sse.defaultSecurityContext "enabled") }}
-          {{- end }}
-          {{- toYaml $securityContext | nindent 10 }}
+        securityContext: {{- include "flagsmith.mergedSecurityContext" (dict "component" .Values.sse "key" "securityContext") | nindent 10 }}
         resources:
 {{ toYaml .Values.sse.resources | indent 10 }}
         volumeMounts:

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -134,6 +134,12 @@ spec:
         lifecycle:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        securityContext:
+          {{- $securityContext := .Values.taskProcessor.securityContext | default (dict) | deepCopy }}
+          {{- if .Values.taskProcessor.defaultSecurityContext.enabled }}
+          {{- $securityContext = $securityContext | merge (omit .Values.taskProcessor.defaultSecurityContext "enabled") }}
+          {{- end }}
+          {{- toYaml $securityContext | nindent 10 }}
         resources:
 {{ toYaml .Values.taskProcessor.resources | indent 10 }}
         volumeMounts:

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -60,12 +60,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      securityContext:
-        {{- $securityContext := .Values.taskProcessor.podSecurityContext | default (dict) | deepCopy }}
-        {{- if .Values.taskProcessor.defaultPodSecurityContext.enabled }}
-        {{- $securityContext = $securityContext | merge (omit .Values.taskProcessor.defaultPodSecurityContext "enabled") }}
-        {{- end }}
-        {{- toYaml $securityContext | nindent 8 }}
+      securityContext: {{- include "flagsmith.mergedSecurityContext" (dict "component" .Values.taskProcessor "key" "podSecurityContext") | nindent 8 }}
       {{- if .Values.taskProcessor.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.taskProcessor.terminationGracePeriodSeconds }}
       {{- end }}
@@ -134,12 +129,7 @@ spec:
         lifecycle:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        securityContext:
-          {{- $securityContext := .Values.taskProcessor.securityContext | default (dict) | deepCopy }}
-          {{- if .Values.taskProcessor.defaultSecurityContext.enabled }}
-          {{- $securityContext = $securityContext | merge (omit .Values.taskProcessor.defaultSecurityContext "enabled") }}
-          {{- end }}
-          {{- toYaml $securityContext | nindent 10 }}
+        securityContext: {{- include "flagsmith.mergedSecurityContext" (dict "component" .Values.taskProcessor "key" "securityContext") | nindent 10 }}
         resources:
 {{ toYaml .Values.taskProcessor.resources | indent 10 }}
         volumeMounts:

--- a/charts/flagsmith/templates/jobs-migrate-analytics-data.yaml
+++ b/charts/flagsmith/templates/jobs-migrate-analytics-data.yaml
@@ -23,12 +23,7 @@ spec:
       {{- if .Values.jobs.migrateDb.shareProcessNamespace }}
       {{- end }}
       shareProcessNamespace: true
-      securityContext:
-        {{- $securityContext := .Values.jobs.migrateAnalyticsData.podSecurityContext | default (dict) | deepCopy }}
-        {{- if .Values.jobs.migrateAnalyticsData.defaultPodSecurityContext.enabled }}
-        {{- $securityContext = $securityContext | merge (omit .Values.jobs.migrateAnalyticsData.defaultPodSecurityContext "enabled") }}
-        {{- end }}
-        {{- toYaml $securityContext | nindent 8 }}
+      securityContext: {{- include "flagsmith.mergedSecurityContext" (dict "component" .Values.jobs.migrateAnalyticsData "key" "podSecurityContext") | nindent 8 }}
       containers:
       - name: migrate-analytics-data
         image: {{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default .Chart.AppVersion }}
@@ -36,12 +31,7 @@ spec:
         {{- if .Values.jobs.migrateAnalyticsData.args }}
         args: {{ toYaml .Values.jobs.migrateAnalyticsData.args | nindent 8 }}
         {{- end }}
-        securityContext:
-          {{- $securityContext := .Values.jobs.migrateAnalyticsData.securityContext | default (dict) | deepCopy }}
-          {{- if .Values.jobs.migrateAnalyticsData.defaultSecurityContext.enabled }}
-          {{- $securityContext = $securityContext | merge (omit .Values.jobs.migrateAnalyticsData.defaultSecurityContext "enabled") }}
-          {{- end }}
-          {{- toYaml $securityContext | nindent 10 }}
+        securityContext: {{- include "flagsmith.mergedSecurityContext" (dict "component" .Values.jobs.migrateAnalyticsData "key" "securityContext") | nindent 10 }}
         env: {{ include (print $.Template.BasePath "/_api_environment.yaml") . | nindent 8 }}
 {{- with .Values.jobs.migrateDb.extraContainers }}
 {{ if typeIs "string" . }}

--- a/charts/flagsmith/templates/jobs-migrate-analytics-data.yaml
+++ b/charts/flagsmith/templates/jobs-migrate-analytics-data.yaml
@@ -23,6 +23,12 @@ spec:
       {{- if .Values.jobs.migrateDb.shareProcessNamespace }}
       {{- end }}
       shareProcessNamespace: true
+      securityContext:
+        {{- $securityContext := .Values.jobs.migrateAnalyticsData.podSecurityContext | default (dict) | deepCopy }}
+        {{- if .Values.jobs.migrateAnalyticsData.defaultPodSecurityContext.enabled }}
+        {{- $securityContext = $securityContext | merge (omit .Values.jobs.migrateAnalyticsData.defaultPodSecurityContext "enabled") }}
+        {{- end }}
+        {{- toYaml $securityContext | nindent 8 }}
       containers:
       - name: migrate-analytics-data
         image: {{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default .Chart.AppVersion }}
@@ -30,6 +36,12 @@ spec:
         {{- if .Values.jobs.migrateAnalyticsData.args }}
         args: {{ toYaml .Values.jobs.migrateAnalyticsData.args | nindent 8 }}
         {{- end }}
+        securityContext:
+          {{- $securityContext := .Values.jobs.migrateAnalyticsData.securityContext | default (dict) | deepCopy }}
+          {{- if .Values.jobs.migrateAnalyticsData.defaultSecurityContext.enabled }}
+          {{- $securityContext = $securityContext | merge (omit .Values.jobs.migrateAnalyticsData.defaultSecurityContext "enabled") }}
+          {{- end }}
+          {{- toYaml $securityContext | nindent 10 }}
         env: {{ include (print $.Template.BasePath "/_api_environment.yaml") . | nindent 8 }}
 {{- with .Values.jobs.migrateDb.extraContainers }}
 {{ if typeIs "string" . }}

--- a/charts/flagsmith/templates/jobs-migrate-db.yaml
+++ b/charts/flagsmith/templates/jobs-migrate-db.yaml
@@ -72,6 +72,12 @@ spec:
         {{- else }}
         args: ["migrate"]
         {{- end }}
+        securityContext:
+          {{- $securityContext := .Values.jobs.migrateDb.securityContext | default (dict) | deepCopy }}
+          {{- if .Values.jobs.migrateDb.defaultSecurityContext.enabled }}
+          {{- $securityContext = $securityContext | merge (omit .Values.jobs.migrateDb.defaultSecurityContext "enabled") }}
+          {{- end }}
+          {{- toYaml $securityContext | nindent 10 }}
         env:
         {{- include (print $.Template.BasePath "/_api_environment.yaml") . | nindent 8 }}
         {{- if and .Values.jobs.migrateDb.databaseUrl .Values.jobs.migrateDb.databaseUrl.fromExistingSecret.enabled }}

--- a/charts/flagsmith/templates/jobs-migrate-db.yaml
+++ b/charts/flagsmith/templates/jobs-migrate-db.yaml
@@ -48,12 +48,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      securityContext:
-        {{- $securityContext := .Values.jobs.migrateDb.podSecurityContext | default (dict) | deepCopy }}
-        {{- if .Values.jobs.migrateDb.defaultPodSecurityContext.enabled }}
-        {{- $securityContext = $securityContext | merge (omit .Values.jobs.migrateDb.defaultPodSecurityContext "enabled") }}
-        {{- end }}
-        {{- toYaml $securityContext | nindent 8 }}
+      securityContext: {{- include "flagsmith.mergedSecurityContext" (dict "component" .Values.jobs.migrateDb "key" "podSecurityContext") | nindent 8 }}
       {{- if .Values.jobs.migrateDb.serviceAccountName }}
       serviceAccountName: {{ .Values.jobs.migrateDb.serviceAccountName }}
       {{- end }}
@@ -72,12 +67,7 @@ spec:
         {{- else }}
         args: ["migrate"]
         {{- end }}
-        securityContext:
-          {{- $securityContext := .Values.jobs.migrateDb.securityContext | default (dict) | deepCopy }}
-          {{- if .Values.jobs.migrateDb.defaultSecurityContext.enabled }}
-          {{- $securityContext = $securityContext | merge (omit .Values.jobs.migrateDb.defaultSecurityContext "enabled") }}
-          {{- end }}
-          {{- toYaml $securityContext | nindent 10 }}
+        securityContext: {{- include "flagsmith.mergedSecurityContext" (dict "component" .Values.jobs.migrateDb "key" "securityContext") | nindent 10 }}
         env:
         {{- include (print $.Template.BasePath "/_api_environment.yaml") . | nindent 8 }}
         {{- if and .Values.jobs.migrateDb.databaseUrl .Values.jobs.migrateDb.databaseUrl.fromExistingSecret.enabled }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -94,6 +94,15 @@ api:
     # runAsNonRoot: true  # TODO: enable this, conditional on tag semver
     # runAsUser: 1000
     # runAsGroup: 1000
+  # Applies to the flagsmith-api container, the migrate-db init container,
+  # and the bootstrap init container (all run the same image).
+  securityContext: {}
+  defaultSecurityContext:
+    enabled: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
   livenessProbe:
     # path is the API path to be used for health checks. Used if exec is not set.
     path: /health/liveness/
@@ -188,6 +197,13 @@ frontend:
     # runAsNonRoot: true  # TODO: enable this, conditional on tag semver
     # runAsUser: 1000
     # runAsGroup: 1000
+  securityContext: {}
+  defaultSecurityContext:
+    enabled: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
   livenessProbe:
     failureThreshold: 20
     initialDelaySeconds: 20
@@ -271,6 +287,13 @@ taskProcessor:
     # runAsNonRoot: true  # TODO: enable this, conditional on tag semver
     # runAsUser: 1000
     # runAsGroup: 1000
+  securityContext: {}
+  defaultSecurityContext:
+    enabled: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
   extraInitContainers: []
   extraContainers: []
   extraEnv: {}
@@ -427,6 +450,13 @@ sse:
     # runAsNonRoot: true  # TODO: enable this, conditional on tag semver
     # runAsUser: 1000
     # runAsGroup: 1000
+  securityContext: {}
+  defaultSecurityContext:
+    enabled: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
   livenessProbe:
     path: /health/liveness/
     failureThreshold: 5
@@ -591,9 +621,17 @@ jobs:
     annotations: {}
     ttlSecondsAfterFinished: 3600
     restartPolicy: OnFailure
+    podSecurityContext: {}
     defaultPodSecurityContext:
       enabled: true
       # runAsNonRoot: true
+    securityContext: {}
+    defaultSecurityContext:
+      enabled: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
     extraContainers: []
     extraVolumes: []
     command: []
@@ -615,6 +653,17 @@ jobs:
     # itself (`metadata.annotations`). See `jobs.migrateDb.annotations`
     # for typical use cases (Helm hooks, ArgoCD sync waves, etc.).
     annotations: {}
+    podSecurityContext: {}
+    defaultPodSecurityContext:
+      enabled: true
+      # runAsNonRoot: true
+    securityContext: {}
+    defaultSecurityContext:
+      enabled: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
     args: []
     extraContainers: []
     extraVolumes: []


### PR DESCRIPTION
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

`pgbouncer` is currently the only component in this chart whose container renders `securityContext` — it's the only one with both `securityContext`/`defaultSecurityContext` in `values.yaml` *and* the corresponding container-level block in its Deployment template. Every other component (`api`, `frontend`, `taskProcessor`, `sse`, the `migrate-db`/`bootstrap` init containers, `jobs.migrateDb`, `jobs.migrateAnalyticsData`) only exposes `podSecurityContext`/`defaultPodSecurityContext` (pod-level). Since `allowPrivilegeEscalation` and `capabilities.drop` are container-only fields, there is currently no way — via `values.yaml` or otherwise — to make any of those components satisfy Kubernetes' [restricted Pod Security Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted), which requires both.

This PR mirrors the existing `pgbouncer` pattern onto the rest of the chart:
- Adds `securityContext: {}` / `defaultSecurityContext: {enabled: true, allowPrivilegeEscalation: false, capabilities.drop: [ALL]}` to `api`, `frontend`, `taskProcessor`, `sse`, `jobs.migrateDb`, and `jobs.migrateAnalyticsData` in `values.yaml`.
- Wires that into the container spec in `deployment-api.yaml` (main container + `migrate-db` and `bootstrap` init containers, which share `api`'s image and now share its `securityContext`), `deployment-frontend.yaml`, `deployment-task-processor.yaml`, `deployment-sse.yaml`, `jobs-migrate-db.yaml`, and `jobs-migrate-analytics-data.yaml`.
- `jobs.migrateAnalyticsData` was also missing `podSecurityContext`/`defaultPodSecurityContext` entirely (unlike `jobs.migrateDb`, which already had it) — added that too, so the Job now sets pod-level security context at all.

Defaults to `enabled: true`, matching `pgbouncer`'s own default. `allowPrivilegeEscalation: false` + dropping all capabilities is safe regardless of which UID a container runs as, so this shouldn't be breaking — unlike `runAsNonRoot` (left commented out chart-wide, presumably because some image tags may still run as root).

Not included: the `secret-creator` container in the `django-secret-init`/`sse-secret-init` helper Jobs has the same gap but no existing `securityContext` values plumbing to extend (no `podSecurityContext` equivalent either), so it's a separate shaped change — happy to follow up in another PR if useful.

## How did you test this code?

`helm lint` and `helm template` locally against:
- The chart's default values
- Each existing file under `charts/flagsmith/ci/*.yaml`
- An ad-hoc values file enabling every optional component together (`api.bootstrap`, `taskProcessor`, `sse`, `jobs.migrateDb`, `jobs.migrateAnalyticsData`, `databaseExternal`) to render every container this PR touches in one pass

Then walked the rendered manifests and confirmed every targeted container (`flagsmith-api`, `bootstrap`, `migrate-db` init container, `flagsmith-frontend`, `flagsmith-task-processor`, `flagsmith-sse`, and both `migrate-db`/`migrate-analytics-data` Job containers) carries `securityContext: {allowPrivilegeEscalation: false, capabilities: {drop: [ALL]}}`, and that the default (no extra values) render is unaffected.

Motivated by a real deployment: we run this chart in an EKS namespace with `pod-security.kubernetes.io/{audit,warn}=restricted`, and `flagsmith-frontend` and the `migrate-db` init container currently show up as PodSecurity violations with no way to resolve them through `values.yaml`.
