### PR TITLE
fix(pgbouncer): PgBouncer cannot run in a namespace with restricted Pod Security enforced

### DIFF
--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -343,7 +343,7 @@ pgbouncer:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-        - all
+        - ALL
 
   livenessProbe:
     failureThreshold: 5


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

PgBouncer would not start in namespaces that enforce Kubernetes' `restricted` security level. Kubernetes rejected the pod, and there was no way to fix it from `values.yaml`.

The chart told Kubernetes to remove all Linux capabilities from the container, but spelled the value `all` instead of `ALL`. Container runtimes accept either spelling, so the container did run with no capabilities. The Kubernetes security check only accepts `ALL`, so it rejected the pod anyway.

- [x] Change `all` to `ALL` for the pgbouncer container.

Nothing changes at runtime — the container already ran with no capabilities. This only makes the security check pass. PgBouncer was the only component using the lowercase spelling.

## How did you test this code?

1. Create a namespace that enforces the `restricted` level:
   ```bash
   kubectl create ns pgb-test
   kubectl label ns pgb-test pod-security.kubernetes.io/enforce=restricted
   ```
2. Render the chart with pgbouncer on:
   ```bash
   helm template t charts/flagsmith \
     --set pgbouncer.enabled=true \
     --set databaseExternal.enabled=true \
     --set databaseExternal.url=postgres://u:p@h:5432/d \
     --set pgbouncer.podSecurityContext.runAsNonRoot=true \
     --set pgbouncer.podSecurityContext.runAsUser=1000 \
     --set pgbouncer.podSecurityContext.seccompProfile.type=RuntimeDefault
   ```
3. Copy the pgbouncer pod template into its own Pod file and apply it:
   ```bash
   kubectl -n pgb-test apply --dry-run=server -f pgbouncer-pod.yaml
   ```
   The check has to run against a Pod. Deployments only get a warning.

Before this change Kubernetes replies:

```
pods "...-pgbouncer" is forbidden: violates PodSecurity "restricted:latest":
unrestricted capabilities (container "flagsmith-pgbouncer" must set
securityContext.capabilities.drop=["ALL"])
```

After this change the pod is accepted.

Also ran `helm lint`. In a live install with `pgbouncer.enabled=true`, the PgBouncer pod ran `1/1 Ready` with `capabilities.drop: [ALL]` on the container, confirming the container still starts with the corrected spelling.

Tested on Kubernetes v1.35.1.

Review effort: 1/5
