### PR TITLE
fix(pgbouncer): PgBouncer is unreachable when the release name does not contain "flagsmith"

### DIFF
--- a/charts/flagsmith/templates/_helpers.tpl
+++ b/charts/flagsmith/templates/_helpers.tpl
@@ -196,7 +196,7 @@ Postgres hostname
 PgBouncer hostname
 */}}
 {{- define "flagsmith.pgbouncer.hostname" -}}
-{{- printf "%s-%s" .Release.Name "pgbouncer" -}}.{{ include "flagsmith.namespace" . }}.svc.cluster.local
+{{- template "flagsmith.fullname" . }}-pgbouncer.{{ include "flagsmith.namespace" . }}.svc.cluster.local
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

With PgBouncer switched on, the API never started — it could not reach PgBouncer.

The chart built PgBouncer's name in two different ways, so the address given to the API did not match the name of the PgBouncer service. They only matched when the release name contained "flagsmith", which is what our docs use, so nobody hit it.

| Release name | PgBouncer service | Address given to the API | |
| --- | --- | --- | --- |
| `flagsmith` | `flagsmith-pgbouncer` | `flagsmith-pgbouncer` | works |
| `fs` | `fs-flagsmith-pgbouncer` | `fs-pgbouncer` | broken |

- [x] Build the address the same way the service name is built.

Note for release notes: anyone who worked around this with `fullnameOverride` will see the address change again.

## How did you test this code?

```bash
helm install fs charts/flagsmith -n test --set pgbouncer.enabled=true --wait
```

Before: API pod stuck retrying `could not translate host name "fs-pgbouncer..."`.
After: install finishes, API pod `1/1 Running`, PgBouncer logs show it logging in.

Also rendered four release names plus `nameOverride` and `fullnameOverride` — address matches the service every time, and the names that already worked are unchanged. `helm lint` passes. Kubernetes v1.35.1.

Review effort: 1/5
