### PR TITLE
feat(api): Add a startup probe so a slow start does not restart the API

### DIFF
--- a/charts/flagsmith/templates/_helpers.tpl
+++ b/charts/flagsmith/templates/_helpers.tpl
@@ -378,3 +378,30 @@ Usage: (dict "component" .Values.api "key" "securityContext"|"podSecurityContext
 {{- end -}}
 {{- toYaml $ctx -}}
 {{- end -}}
+
+{{/*
+Container probe, with its field name. Set the probe to null to leave it out.
+`exec` and `path` are shorthands for the handler: `exec` wins, `path` becomes an
+`httpGet` on `port`. Every other key passes through, so to use a `tcpSocket`,
+`grpc` or full `httpGet` handler, clear `path` and write it in the probe values.
+`port` is the name of the container port to probe, so that the probe follows the
+port wherever it moves.
+Usage: (dict "name" "livenessProbe" "probe" .Values.api.livenessProbe "port" "http")
+  Add "defaultExec" to fall back to another component's exec handler.
+*/}}
+{{- define "flagsmith.probe" -}}
+{{- with .probe -}}
+{{- $probe := omit . "exec" "path" -}}
+{{- $exec := .exec | default $.defaultExec -}}
+{{- if $exec -}}
+{{- $probe = set $probe "exec" $exec -}}
+{{- else if .path -}}
+{{- $probe = set $probe "httpGet" (dict "path" .path "port" $.port "scheme" "HTTP") -}}
+{{- end -}}
+{{- if not (or $probe.exec $probe.httpGet $probe.tcpSocket $probe.grpc) -}}
+{{- fail (printf "%s needs a handler. Set `path` or `exec`, or write an `httpGet`, `tcpSocket` or `grpc` handler in the probe values. To remove the probe, set %s to null." $.name $.name) -}}
+{{- end -}}
+{{ $.name }}:
+{{- toYaml $probe | nindent 2 }}
+{{- end -}}
+{{- end -}}

--- a/charts/flagsmith/templates/deployment-api.yaml
+++ b/charts/flagsmith/templates/deployment-api.yaml
@@ -130,34 +130,9 @@ spec:
           containerPort: 9100
         {{- end }}
         env: {{ include (print $.Template.BasePath "/_api_environment.yaml") . | nindent 8 }}
-        livenessProbe:
-          {{- if .Values.api.livenessProbe.exec }}
-          exec: {{ .Values.api.livenessProbe.exec | toYaml | nindent 12 }}
-          {{- else if .Values.api.livenessProbe.path }}
-          httpGet:
-            path: {{ .Values.api.livenessProbe.path }}
-            port: {{ .Values.service.api.port }}
-            scheme: HTTP
-          {{- end }}
-          failureThreshold: {{ .Values.api.livenessProbe.failureThreshold }}
-          initialDelaySeconds: {{ .Values.api.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.api.livenessProbe.periodSeconds }}
-          successThreshold: {{ .Values.api.livenessProbe.successThreshold }}
-          timeoutSeconds: {{ .Values.api.livenessProbe.timeoutSeconds }}
-        readinessProbe:
-          {{- if .Values.api.readinessProbe.exec }}
-          exec: {{ .Values.api.readinessProbe.exec | toYaml | nindent 12 }}
-          {{- else if .Values.api.readinessProbe.path }}
-          httpGet:
-            path: {{ .Values.api.readinessProbe.path }}
-            port: {{ .Values.service.api.port }}
-            scheme: HTTP
-          {{- end }}
-          failureThreshold: {{ .Values.api.readinessProbe.failureThreshold }}
-          initialDelaySeconds: {{ .Values.api.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.api.readinessProbe.periodSeconds }}
-          successThreshold: {{ .Values.api.readinessProbe.successThreshold }}
-          timeoutSeconds: {{ .Values.api.readinessProbe.timeoutSeconds }}
+        {{- include "flagsmith.probe" (dict "name" "livenessProbe" "probe" .Values.api.livenessProbe "port" "http") | nindent 8 }}
+        {{- include "flagsmith.probe" (dict "name" "readinessProbe" "probe" .Values.api.readinessProbe "port" "http") | nindent 8 }}
+        {{- include "flagsmith.probe" (dict "name" "startupProbe" "probe" .Values.api.startupProbe "port" "http") | nindent 8 }}
         {{- with .Values.api.lifecycle }}
         lifecycle:
           {{- toYaml . | nindent 10 }}

--- a/charts/flagsmith/templates/deployment-task-processor.yaml
+++ b/charts/flagsmith/templates/deployment-task-processor.yaml
@@ -95,36 +95,9 @@ spec:
           containerPort: 9100
         {{- end }}
         env: {{ include (print $.Template.BasePath "/_task_processor_environment.yaml") . | nindent 8 }}
-        livenessProbe:
-          {{- $exec := .Values.taskProcessor.livenessProbe.exec | default .Values.api.livenessProbe.exec }}
-          {{- if $exec }}
-          exec: {{ $exec | toYaml | nindent 12 }}
-          {{- else }}
-          httpGet:
-            path: /health/liveness/
-            port: {{ .Values.service.taskProcessor.port }}
-            scheme: HTTP
-          {{- end }}
-          failureThreshold: {{ .Values.taskProcessor.livenessProbe.failureThreshold }}
-          initialDelaySeconds: {{ .Values.taskProcessor.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.taskProcessor.livenessProbe.periodSeconds }}
-          successThreshold: {{ .Values.taskProcessor.livenessProbe.successThreshold }}
-          timeoutSeconds: {{ .Values.taskProcessor.livenessProbe.timeoutSeconds }}
-        readinessProbe:
-          {{- $exec := .Values.taskProcessor.readinessProbe.exec | default .Values.api.readinessProbe.exec }}
-          failureThreshold: {{ .Values.taskProcessor.readinessProbe.failureThreshold }}
-          {{- if $exec }}
-          exec: {{ $exec | toYaml | nindent 12 }}
-          {{- else }}
-          httpGet:
-            path: /health/readiness/
-            port: {{ .Values.service.taskProcessor.port }}
-            scheme: HTTP
-          {{- end }}
-          initialDelaySeconds: {{ .Values.taskProcessor.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.taskProcessor.readinessProbe.periodSeconds }}
-          successThreshold: {{ .Values.taskProcessor.readinessProbe.successThreshold }}
-          timeoutSeconds: {{ .Values.taskProcessor.readinessProbe.timeoutSeconds }}
+        {{- /* defaultExec: the task processor has no health endpoints of its own, so it reuses the API's exec probe. */}}
+        {{- include "flagsmith.probe" (dict "name" "livenessProbe" "probe" .Values.taskProcessor.livenessProbe "port" "http" "defaultExec" .Values.api.livenessProbe.exec) | nindent 8 }}
+        {{- include "flagsmith.probe" (dict "name" "readinessProbe" "probe" .Values.taskProcessor.readinessProbe "port" "http" "defaultExec" .Values.api.readinessProbe.exec) | nindent 8 }}
         {{- with .Values.taskProcessor.lifecycle }}
         lifecycle:
           {{- toYaml . | nindent 10 }}

--- a/charts/flagsmith/values.yaml
+++ b/charts/flagsmith/values.yaml
@@ -124,6 +124,18 @@ api:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 2
+  # startupProbe holds back the liveness and readiness probes until the API
+  # answers. Set `startupProbe: null` to remove the probe from the pod spec.
+  startupProbe:
+    # path is the API path to be used for health checks. Used if exec is not set.
+    path: /health/readiness/
+    # exec describes an ExecAction command which will run inside the API container.
+    # See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe
+    exec: {}
+    # failureThreshold x periodSeconds is the time the API has to start.
+    failureThreshold: 20
+    periodSeconds: 10
+    timeoutSeconds: 2
   statsd:
     enabled: false
     host: null
@@ -245,6 +257,8 @@ taskProcessor:
   queuePopSize: null
 
   livenessProbe:
+    # path is the API path to be used for health checks. Used if exec is not set.
+    path: /health/liveness/
     # exec describes an ExecAction command which will run inside the API container.
     # Defaults to api.livenessProbe.exec.
     # See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe
@@ -255,6 +269,7 @@ taskProcessor:
     successThreshold: 1
     timeoutSeconds: 30
   readinessProbe:
+    path: /health/readiness/
     # exec describes an ExecAction command which will run inside the API container.
     # Defaults to api.readinessProbe.exec.
     # See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe


### PR DESCRIPTION
When it starts, the API can be slow to answer. The kubelet then restarts the container, and a slow start becomes a restart loop. A startup probe delays the liveness and readiness probes until the API answers one time.

- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

- [x] The API waits for a startup probe, and has 200 seconds to start. It is on by default. To keep the old behavior, set `api.startupProbe: null`.
- [x] All probes of the API and the task processor render from one shared template.
- [x] Probe values accept every field of the Kubernetes Probe spec, such as `tcpSocket` and `grpc`.
- [x] Probes target the named container port `http`, so a probe follows its port.
- [x] A probe without a handler stops `helm template` and gives the reason.

## How did you test this code?

Manually, with `helm template`. CI runs `ct install`.

I compared every probe of every container across 18 sets of values against `main`.

`helm lint` and `yamllint` are clean. All four `ci/*-values.yaml` render.